### PR TITLE
Add corpus.xml

### DIFF
--- a/corpus.xml
+++ b/corpus.xml
@@ -9,6 +9,11 @@
         <publisher>DraCor</publisher>
         <idno type="URI" xml:base="https://dracor.org/">fre</idno>
         <idno type="repo">https://github.com/dracor-org/fredracor</idno>
+        <availability>
+          <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            CC BY-NC-SA 4.0
+          </licence>
+        </availability>
       </publicationStmt>
     </fileDesc>
     <encodingDesc>


### PR DESCRIPTION
This add the main metadata and description for FreDraCor.

It is still missing the licensing information. The [home page of Théâtre classique](http://theatre-classique.fr/) says [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/). While we may have Paul Fievre's consent in email, wouldn't "Pas de Modification" (No Derivatives) strictly speaking prevent us from importing his files into DraCor?