### PR TITLE
Partly automate author updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 report-*.log
+authors.update*.xml

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ instances can be started in parallel using either [Podman](https://podman.io) or
 
 1. start one or more pods (or containers) running eXist-db
 2. loading the transformation XQuery [`tc2dracor.xq`](tc2dracor.xq) and
-   auxiliary files ([authors.xml](authors.xml), [ids.xml](ids.xml)) to the
+   auxiliary files ([authors.xml](#authorsxml), [ids.xml](ids.xml)) to the
    database(s)
 3. process each source file by posting it to the transformation XQuery and
    storing the output to the [tei](tei) directory
@@ -168,6 +168,36 @@ podman logs -f $(cat $(ls -rtd /tmp/tc2dracor-* | tail -1)/containers)
 For debugging purposes the logs of all containers are also stored in a temporary
 working directory after the transformation has finished. Use the `-v` option to
 see the exact location of these files at the end of the script run.
+
+### authors.xml
+
+The transformation process uses the file [authors.xml](authors.xml) to unify
+and enrich author information within FreDraCor. The entries in this file provide
+a canonical `tei:author` element for each author together with the matching
+author string in the source documents (in the  `name` elements), e.g.:
+
+```xml
+<author>
+  <author xmlns="http://www.tei-c.org/ns/1.0">
+    <persName>
+      <forename>Charles</forename>
+      <surname>Collé</surname>
+    </persName>
+    <idno type="isni">0000000121258527</idno>
+    <idno type="wikidata">Q2404425</idno>
+  </author>
+  <name>Charles COLLÉ (1709-1783)</name>
+  <name>COLLE, Charles</name>
+  <isni>0000 0001 2125 8527</isni>
+</author>
+```
+
+When the transformation script discovers an author that does not yet have an
+entry in authors.xml, trying to properly identify the name parts and also
+looking up the Wikidata ID if the source TEI provides an ISNI. The new entries
+are written to the file `authors.update.xxxx.xml` (where 'xxxx' is the eXist DB
+port number used to run the transformation). This file should be merged manually
+into `authors.xml`.
 
 ## TODO
 

--- a/authors.xml
+++ b/authors.xml
@@ -5557,7 +5557,7 @@ tei:author tags.
         <forename>Xavier</forename>
         <surname>Aubryet</surname>
       </persName>
-      <idno type="isni">0000 0000 0063 4768</idno>
+      <idno type="isni">0000000000634768</idno>
     </author>
     <name>Xavier AUBRYET (1827-1880)</name>
     <isni>0000 0000 0063 4768</isni>
@@ -5568,7 +5568,7 @@ tei:author tags.
         <forename>Hippolyte</forename>
         <surname>Auger</surname>
       </persName>
-      <idno type="isni">0000 0000 7991 7356</idno>
+      <idno type="isni">0000000079917356</idno>
     </author>
     <name>Hippolyte Hippolyte AUGER (1796-1881) (1796-1881)</name>
     <isni>0000 0000 7991 7356</isni>
@@ -5579,7 +5579,7 @@ tei:author tags.
         <forename>Fernand</forename>
         <surname>Beissier</surname>
       </persName>
-      <idno type="isni">0000 0001 1474 4543</idno>
+      <idno type="isni">0000000114744543</idno>
     </author>
     <name>BEISSIER, Fernand (1858-1936)</name>
     <isni>0000 0001 1474 4543</isni>
@@ -5599,7 +5599,7 @@ tei:author tags.
         <forename>Adolphe</forename>
         <surname>Carcassonne</surname>
       </persName>
-      <idno type="isni">0000 0001 1756 1275</idno>
+      <idno type="isni">0000000117561275</idno>
     </author>
     <name>Adolphe CARCASSONNE (1826-1891)</name>
     <isni>0000 0001 1756 1275</isni>
@@ -5610,7 +5610,7 @@ tei:author tags.
         <forename>Maurice</forename>
         <surname>Donnay</surname>
       </persName>
-      <idno type="isni">0000 0001 1022 8218</idno>
+      <idno type="isni">0000000110228218</idno>
     </author>
     <name>Maurice DONNAY (1859-1945)</name>
     <isni>0000 0001 1022 8218</isni>
@@ -5621,7 +5621,7 @@ tei:author tags.
         <forename>Léopold</forename>
         <surname>Hervieux</surname>
       </persName>
-      <idno type="isni">0000 0001 2120 0982</idno>
+      <idno type="isni">0000000121200982</idno>
     </author>
     <name>Léopold HERVIEUX (1831-1900)</name>
     <isni>0000 0001 2120 0982</isni>
@@ -5660,7 +5660,7 @@ tei:author tags.
         <nameLink>de</nameLink>
         <surname>Nittis</surname>
       </persName>
-      <idno type="isni">0000 0000 0168 1531</idno>
+      <idno type="isni">0000000001681531</idno>
     </author>
     <name>NITTIS, Jacques de (1872-1907)</name>
     <isni>0000 0000 0168 1531</isni>
@@ -5671,7 +5671,7 @@ tei:author tags.
         <forename>Charles</forename>
         <surname>Perrault</surname>
       </persName>
-      <idno type="isni">0000 0001 2127 2484</idno>
+      <idno type="isni">0000000121272484</idno>
     </author>
     <name>Charles PERRAULT (1628-1703)</name>
     <isni>0000 0001 2127 2484</isni>

--- a/tc2dracor
+++ b/tc2dracor
@@ -39,6 +39,24 @@ log () {
     && echo "Detailed log in $logfile"
 }
 
+fetch_authors () {
+  for port in ${PORTS[@]}; do
+    update_file=authors.update.$port.xml
+    # we prepend the xml declaration and append a newline since these seen to be
+    # stripped by eXist
+    echo '<?xml version="1.0" encoding="UTF-8"?>' > $update_file
+    curl -s -o >(cat >> $update_file) \
+      http://admin:@localhost:$port/exist/rest/db/tc2dracor/authors.xml
+    echo "" >> $update_file
+    if cmp -s authors.xml $update_file; then
+      # no difference
+      rm $update_file
+    else
+      echo "Updated author file: $update_file"
+    fi
+  done
+}
+
 stopContainer () {
   # remove containers
   for c in ${CONTAINERS[@]}; do
@@ -318,6 +336,7 @@ wait > /dev/null
 [ -z $VERBOSE ] || echo "$(date +'%T') :: transformation done"
 
 # terminate
+fetch_authors
 log
 stopContainer
 

--- a/tc2dracor.xq
+++ b/tc2dracor.xq
@@ -101,7 +101,7 @@ declare function local:update-authors ($entry) {
   update insert $entry into $author-map/authors
 };
 
-declare function local:make-authors ($doc) {
+declare function local:make-authors ($doc, $filename) {
   (: FIXME: use more specific XPath to find author :)
   for $author in $doc//*:author
     let $content := normalize-space($author)
@@ -137,6 +137,7 @@ declare function local:make-authors ($doc) {
 
       let $author-entry :=
         <author>
+          {comment {'Source: ' || $filename}}
           {$tei-author}
           <name>{$content}</name>
           {if ($isni) then <isni>{$isni}</isni> else ()}
@@ -887,7 +888,7 @@ declare function local:construct-tei (
       else $title-part/text()
     }
 
-  let $authors := local:make-authors($doc)
+  let $authors := local:make-authors($doc, $orig-name)
 
   let $genre := lower-case($doc//*:SourceDesc/*:genre)
   let $class-codes := (


### PR DESCRIPTION
The transformation script during an update now creates new entries for authors.xml when it finds an author not yet recorded there. If the new author has an ISNI in the TC source we also try to look up their Wikidata ID.

resolve #12