### PR TITLE
Improve transformation of `who` attributes

### DIFF
--- a/tc2dracor.xq
+++ b/tc2dracor.xq
@@ -284,24 +284,13 @@ declare function local:transform($nodes) {
         }
 
       case element(sp) return
-        let $exceptionsWho := (
-          $node/@who,
-          $node/@stwho,
-          $node/@givewho,
-          $node/@towardwho,
-          $node/@embarrassedwho,
-          $node/@breakwho,
-          $node/@ho,
-          $node/@w4ho
-        )
-        return
         if( not(exists($node/* except $node/*:speaker)) )
         then comment { 'ERROR: ', serialize($node)}
         else
         element {QName('http://www.tei-c.org/ns/1.0', 'sp')} {
-          $node/@* except ($node/@stage, $exceptionsWho, $node/@type),
+          $node/@* except ($node/@stage, $node/@who, $node/@type),
           attribute who {
-            let $easy := tokenize(string-join($exceptionsWho, ' '), $who-tokenize-pattern)
+            let $easy := tokenize(string-join($node/@who, ' '), $who-tokenize-pattern)
                               ! ('#' || local:translate(.))
             return
               if(string($easy[1]) != '')
@@ -717,7 +706,7 @@ declare function local:transform($nodes) {
 };
 
 declare function local:make-particDesc ($doc as element()) as node()* {
-  let $whos := ($doc//*:text//*:sp/tokenize(./@who || ./@ho || ./@w4ho, $who-tokenize-pattern) => distinct-values())
+  let $whos := ($doc//*:text//*:sp/tokenize(./@who, $who-tokenize-pattern) => distinct-values())
   let $whos := if(string($whos[1]) != '') then $whos else (($doc//*:speaker/string(.)) => distinct-values())
   return if (count($whos)) then
     element {QName('http://www.tei-c.org/ns/1.0', 'particDesc')} {

--- a/tc2dracor.xq
+++ b/tc2dracor.xq
@@ -706,8 +706,13 @@ declare function local:transform($nodes) {
 };
 
 declare function local:make-particDesc ($doc as element()) as node()* {
-  let $whos := ($doc//*:text//*:sp/tokenize(./@who, $who-tokenize-pattern) => distinct-values())
-  let $whos := if(string($whos[1]) != '') then $whos else (($doc//*:speaker/string(.)) => distinct-values())
+  let $whos := (for $sp in $doc//*:text//*:sp
+    return if ($sp/@who != '') then
+      tokenize($sp/@who, $who-tokenize-pattern)
+    else if ($sp/*:speaker[matches(., '\p{L}')]) then
+      replace($sp/*:speaker, "([-\p{L}' ]+).*", '$1')
+    else ()) => distinct-values()
+
   return if (count($whos)) then
     element {QName('http://www.tei-c.org/ns/1.0', 'particDesc')} {
       element {QName('http://www.tei-c.org/ns/1.0', 'listPerson')} {

--- a/tc2dracor.xq
+++ b/tc2dracor.xq
@@ -220,29 +220,6 @@ declare function local:transform($nodes) {
   return
     typeswitch ( $node )
 
-      (:  👇 the incredible typo hack  :)
-      case element(SPEAKER) return
-        element {QName('', 'speaker')} {
-        $node/node()} => local:transform()
-      case element(P) return
-        element {QName('', 'p')} {
-        $node/node()} => local:transform()
-      case element(acheverImprimer) return
-        element {QName('', 'acheveImprime')} {
-        $node/node()} => local:transform()
-      case element(achevedImprime) return
-        element {QName('', 'acheveImprime')} {
-        $node/node()} => local:transform()
-      case element(acheveImprimer) return
-        element {QName('', 'acheveImprime')} {
-        $node/node()} => local:transform()
-      case element(appobation) return
-        element {QName('', 'approbation')} {
-        $node/node()} => local:transform()
-      case element(pinter) return
-        element {QName('', 'printer')} {
-        $node/node()} => local:transform()
-
       case text() return
         (: replace occurrences of 'quart_d_heure' :)
         (: see https://github.com/dracor-org/theatre-classique/commit/0e1f871dea95f4343895dad7e648de750c6dcf91 :)

--- a/tei/allainval-hiver.xml
+++ b/tei/allainval-hiver.xml
@@ -72,8 +72,8 @@
                     <person xml:id="la-volupte" sex="FEMALE">
                         <persName>La Volupté</persName>
                     </person>
-                    <person xml:id="jeux_ris_graces" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Jeux_ris_graces</persName>
+                    <person xml:id="jeux-ris" sex="UNKNOWN">
+                        <persName>Les Jeux et les Ris de la Suite de l'Hiver</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -138,7 +138,7 @@
 	<castItem>
                     <role corresp="#bacchus">BACCHUS</role>.</castItem> 
 	<castItem>
-                    <role corresp="#jeux">Les Jeux et les Ris de la Suite de l'Hiver</role>.</castItem> 
+                    <role corresp="#jeux-ris">Les Jeux et les Ris de la Suite de l'Hiver</role>.</castItem> 
 	</castList>
 <!--TODO: usage of set in correct place but with unknown attributes <set location="Paris" country="France" periode="(indéterminé)" gps="48.856614, 2.352222">La scène est à Paris.</set>-->
 </front>
@@ -2144,7 +2144,7 @@
                     <head>DIVERTISSEMENT.</head>
 <stage type="entrance">Le Bal amène les Jeux, les Ris et les Grâces.</stage>
 <stage type="musique">MARCHE.</stage>
-<sp who="#jeux_ris_graces">
+<sp who="#jeux-ris">
                         <speaker>[JEUX, RIS et GRACES].</speaker>
                         <stage type="music">Air.</stage>
                         <l n="857">Venez plaisirs charmants et doux ;</l>
@@ -2176,7 +2176,7 @@
 </div>
 <div type="scene" n="15">
                     <head>VAUDEVILLE.</head>
-<sp who="#jeux_ris_graces">
+<sp who="#jeux-ris">
                         <speaker>[JEUX, RIS et GRACES].</speaker>
                         <l n="879">Quand un jeune amant vif et tendre,</l>
                         <l n="880">A trouvé l'art de nous surprendre,</l>

--- a/tei/andrieux-le-reve-du-mari.xml
+++ b/tei/andrieux-le-reve-du-mari.xml
@@ -53,7 +53,7 @@
                     <person xml:id="emilie" sex="FEMALE">
                         <persName>Emilie</persName>
                     </person>
-                    <person xml:id="gillot" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                    <person xml:id="gillot" sex="MALE">
                         <persName>Gillot</persName>
                     </person>
                     <person xml:id="la-baronne" sex="FEMALE">
@@ -143,7 +143,7 @@
 			<castItem>
                     <role corresp="#la-baronne">LA BARONNE</role>, soeur de Mathilde. Mlle DEMERSON.</castItem>
 			<castItem>
-                    <role corresp="#empty-string">GILLOT</role>, concierge. M. ARMAND-DAILLY.</castItem>
+                    <role corresp="#gillot">GILLOT</role>, concierge. M. ARMAND-DAILLY.</castItem>
 		</castList>
 	<!--TODO: usage of set in correct place but with unknown attributes <set location="Paris" country="France" periode="XVIIIème" gps="46.580224, 0.340375">La scène est en Poitou, dans un château, à la campagne.</set>-->
 </front>

--- a/tei/anonyme-sauvages-civilises.xml
+++ b/tei/anonyme-sauvages-civilises.xml
@@ -99,8 +99,8 @@
                     <person xml:id="louis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Louis</persName>
                     </person>
-                    <person xml:id="guerriers-et-illinois" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Guerriers et Illinois</persName>
+                    <person xml:id="guerriers" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Guerriers</persName>
                     </person>
                     <person xml:id="choeur-general" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur General</persName>
@@ -1123,7 +1123,7 @@ statue d'Ariski, et préparent le bûcher.</stage>
                         <l n="432">Rappelleront ta simplicité</l>
                         <l n="433">Des vertus du premier âge.</l>
                     </sp>
-<sp who="#guerriers-et-illinois">
+<sp who="#guerriers #illinois">
                         <speaker>GUERRIERS et ILLINOIS.</speaker>
                         <l n="434">Nous renonçons, </l>
                         <l n="435">Aux sanglantes conquêtes ;</l>

--- a/tei/barre-radet-candide.xml
+++ b/tei/barre-radet-candide.xml
@@ -73,9 +73,6 @@
                     <person xml:id="tous" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous</persName>
                     </person>
-                    <person xml:id="madame--de-candide" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Madame de Candide</persName>
-                    </person>
                     <person xml:id="osmin" sex="MALE">
                         <persName>Osmin</persName>
                     </person>

--- a/tei/bary-du-beau-sein.xml
+++ b/tei/bary-du-beau-sein.xml
@@ -45,11 +45,11 @@
         <profileDesc>
             <particDesc>
                 <listPerson>
-                    <person xml:id="sinope" sex="FEMALE">
-                        <persName>Sinope</persName>
-                    </person>
                     <person xml:id="tyrisias" sex="MALE">
                         <persName>Tyrisias</persName>
+                    </person>
+                    <person xml:id="sinope" sex="FEMALE">
+                        <persName>Sinope</persName>
                     </person>
                 </listPerson>
             </particDesc>

--- a/tei/biancollelli-foire-galante.xml
+++ b/tei/biancollelli-foire-galante.xml
@@ -61,9 +61,6 @@
                     <person xml:id="une-des-graces" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Une des Graces</persName>
                     </person>
-                    <person xml:id="arlequin-et-pierrot" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Arlequin et Pierrot</persName>
-                    </person>
                     <person xml:id="le-docteur" sex="MALE">
                         <persName>Le Docteur</persName>
                     </person>
@@ -72,9 +69,6 @@
                     </person>
                     <person xml:id="marinette" sex="FEMALE">
                         <persName>Marinette</persName>
-                    </person>
-                    <person xml:id="le-choeur-et-le-docteur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Choeur et le Docteur</persName>
                     </person>
                     <person xml:id="les-chanteuses" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Chanteuses</persName>
@@ -317,7 +311,7 @@
                         <l n="88">Et Tircis sans le cocuage,</l>
                         <l n="89">Serait-il ce qu'il est ?</l>
                     </sp>
-<sp who="#arlequin-et-pierrot">
+<sp who="#arlequin #pierrot">
                         <speaker>ARLEQUIN et PIERROT, sur le même ton, ensemble.</speaker>
                         <l n="90">Devenons par le cocuage</l>
                         <l n="91">Aussi riche qu'il est.</l>
@@ -574,7 +568,7 @@
                         <l n="226">Cette râpe de fer blanc,</l>
                         <l n="227">Cette andouille de Tabac.</l>
                     </sp>
-<sp who="#le-choeur-et-le-docteur">
+<sp who="#le-choeur #le-docteur">
                         <speaker>LE CHOEUR et LE DOCTEUR, à l'imitation de Aimez, aimez, belle bergère, ensemble</speaker>
                         <l n="228">Râpez, râpez, belle bergère,</l>
                         <l n="229">Si vous voulez charmer !</l>

--- a/tei/boissy-babillard.xml
+++ b/tei/boissy-babillard.xml
@@ -66,23 +66,17 @@
                     <person xml:id="la-fleur" sex="MALE">
                         <persName>La Fleur</persName>
                     </person>
-                    <person xml:id="doris_melite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Doris_melite</persName>
-                    </person>
                     <person xml:id="doris" sex="FEMALE">
                         <persName>Doris</persName>
+                    </person>
+                    <person xml:id="melite" sex="FEMALE">
+                        <persName>Mélite</persName>
                     </person>
                     <person xml:id="ismene" sex="FEMALE">
                         <persName>Ismène</persName>
                     </person>
                     <person xml:id="cephise" sex="FEMALE">
                         <persName>Céphise</persName>
-                    </person>
-                    <person xml:id="melite" sex="FEMALE">
-                        <persName>Mélite</persName>
-                    </person>
-                    <person xml:id="leandre_melite_doris" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Leandre_melite_doris</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -779,7 +773,7 @@
 </div>
 <div type="scene" n="9">
                     <head>SCÈNE IX. Léandre, Céphise, Ismène, Hortense, Daphné, Drois, Mélite.</head>
-<sp who="#doris_melite">
+<sp who="#doris #melite">
                         <speaker>DORIS et MÉLITE, entrant les premières. </speaker>
                         <l n="326">Nous nous rendons, madame, et ne disputons plus. </l>
                     </sp>
@@ -1234,7 +1228,7 @@
                         <speaker>DAPHNÉ, à Léandre.</speaker>
                         <l n="409" part="F">Tenez bon. </l>
                     </sp>
-<sp who="#leandre_melite_doris">
+<sp who="#leandre #melite #doris">
                         <speaker>LÉANDRE, MÉLITE, DORIS.</speaker>
                         <l n="410" part="I">Madame... </l>
                     </sp>

--- a/tei/boursault-fete-de-la-seine.xml
+++ b/tei/boursault-fete-de-la-seine.xml
@@ -59,8 +59,11 @@
                     <person xml:id="deux-nereides" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Deux Nereides</persName>
                     </person>
-                    <person xml:id="une-jeune-fontaine-et-un-ruisseau" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Une Jeune Fontaine et un Ruisseau</persName>
+                    <person xml:id="une-jeune-fontaine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Une Jeune Fontaine</persName>
+                    </person>
+                    <person xml:id="un-ruisseau" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Un Ruisseau</persName>
                     </person>
                     <person xml:id="deux-jeunes-ruisseaux" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Deux Jeunes Ruisseaux</persName>
@@ -79,9 +82,6 @@
                     </person>
                     <person xml:id="ensemble" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Ensemble</persName>
-                    </person>
-                    <person xml:id="le-gange-et-le-nil" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Gange et le Nil</persName>
                     </person>
                     <person xml:id="tous-ensemble" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous Ensemble</persName>
@@ -252,7 +252,7 @@
                         <l n="69">Trouvent la fin de leurs peines,</l>
                         <l n="70">Sans jamais changer leurs cours.</l>
                     </sp>
-<sp who="#une-jeune-fontaine-et-un-ruisseau">
+<sp who="#une-jeune-fontaine #un-ruisseau">
                         <speaker>UNE JEUNE FONTAINE ET UN RUISSEAU.</speaker>
                         <l n="71">Le temps d'aimer est un temps admirable ;</l>
                         <l n="72">Mais il ne dure pas assez :</l>
@@ -379,7 +379,7 @@
                         <l n="160">Consolez-vous, vos souffrances</l>
                         <l n="161">Ne dureront pas longtemps.</l>
                     </sp>
-<sp who="#le-gange-et-le-nil">
+<sp who="#le-gange #le-nil">
                         <speaker>LE GANGE et LE NIL.</speaker>
                         <l n="162">Puisse le Ciel qui l'a fait naître</l>
                         <l n="163">Pour affranchir du joug tant de peuples divers,</l>

--- a/tei/cailleau-tragedies-voltaire.xml
+++ b/tei/cailleau-tragedies-voltaire.xml
@@ -56,8 +56,11 @@
                     <person xml:id="artemire" sex="MALE">
                         <persName>Artémire</persName>
                     </person>
-                    <person xml:id="herode-et-mariamne" sex="MALE">
-                        <persName>Herode et Mariamne</persName>
+                    <person xml:id="herode" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Herode</persName>
+                    </person>
+                    <person xml:id="mariamne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Mariamne</persName>
                     </person>
                     <person xml:id="brutus" sex="MALE">
                         <persName>Brutus</persName>
@@ -378,7 +381,7 @@
 	<s n="1">Pourquoi me tirer de la léthargie où j'étais ?</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="2">
 	<s n="1">Ce n'est pas moi. </s>
@@ -441,7 +444,7 @@
 	<s n="1">Vous savez le plaisir que j'ai fait ici ; la foule des spectateurs était si grande, que la salle n'était pas assez vaste pour contenir tout le monde.</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="11">
 	<s n="1">Vengeons nous de l'affront qu'on nous fait.</s>
@@ -492,7 +495,7 @@
 	<s n="1">Mérope est bonne ; il ne faut pas lui vouloir du mal.</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="19">
 	<s n="">Il faudrait aussi reprendre Mahomet ; elle est d'une hardiesse révoltante ; elle imprime trop de terreur.</s>
@@ -532,7 +535,7 @@ pour la première fois au Collège d'Harcour, où l'on assure qu'elle fut bien r
 	<s n="1">Le Public a jugé toutes nos soeurs, et nous nous réservons à juger celle qui vient de naître.</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="25">
 	<s n="2">Voici la Mort de César, Mahomet, Mérope et Sémiramis ; elles ont du dépit : à qui en ont-elles ?</s>
@@ -742,7 +745,7 @@ pour la première fois au Collège d'Harcour, où l'on assure qu'elle fut bien r
 	<s n="5">Regardez donc cette figure hétéroclite qui s'approche de nous.</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="22">
 	<s n="1">Elle n'ose avancer : qu'elle marche lentement !</s>
@@ -1340,7 +1343,7 @@ pour la première fois au Collège d'Harcour, où l'on assure qu'elle fut bien r
 	<s n="1">L'intérêt veut percer ; mais il est encore loin.</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="31">
 	<s n="1">Pour moi je m'y perds, je crains que vous nous embarrassiez dans votre marche.</s>
@@ -1451,7 +1454,7 @@ pour la première fois au Collège d'Harcour, où l'on assure qu'elle fut bien r
 </p>
                         <l n="28">Ô ma fille ! Vivez : fussiez-vous criminelle.</l>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="37">
 	<s n="1">Quelle chaleur ! </s>
@@ -1609,7 +1612,7 @@ pour la première fois au Collège d'Harcour, où l'on assure qu'elle fut bien r
 	<s n="1">Je cause plus de bruit que je n'en fais.</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="61">
 	<s n="1">C'est à dire que vous marchez lentement pour finir.</s>
@@ -1698,7 +1701,7 @@ pour la première fois au Collège d'Harcour, où l'on assure qu'elle fut bien r
 	<s n="2">Son père témoin d'un spectacle si tragique, s'empresse de la secourir et prie les Dieux de la rendre à la vie.</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="77">
 	<s n="1">Je m'attendais à un dénouement plus merveilleux.</s>
@@ -1843,7 +1846,7 @@ L'Orphelin de la Chine, Tancrède.</head>
 	<s n="1">Notre Père vous a ménagé des situations qui vous soutiendront toujours ; mais vous avez des longueurs insupportables.</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE.</speaker>
                         <p n="8">
 	<s n="1">Je me sens si faible auprès de vous, que je suis obligée de sortir. </s>
@@ -1870,7 +1873,7 @@ L'Orphelin de la Chine, Tancrède.</head>
 	<s n="1">Vous la méritez.</s>
 </p>
                     </sp>
-<sp who="#herode-et-mariamne">
+<sp who="#herode #mariamne">
                         <speaker>HÉRODE ET MARIAMNE, en s'en allant.</speaker>
                         <p n="12">
 	<s n="1">Plus je la vois, et plus je me trouve mauvaise.</s>

--- a/tei/campistron-achille.xml
+++ b/tei/campistron-achille.xml
@@ -57,8 +57,8 @@
                     <person xml:id="terpsicore" sex="FEMALE">
                         <persName>Terpsicore</persName>
                     </person>
-                    <person xml:id="melpomeme_terpsicore" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Melpomeme_terpsicore</persName>
+                    <person xml:id="melpomeme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Melpomeme</persName>
                     </person>
                     <person xml:id="choeur-de-genies" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur de Genies</persName>
@@ -87,8 +87,8 @@
                     <person xml:id="un-plaisir" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Plaisir</persName>
                     </person>
-                    <person xml:id="deux-graces-et-un-plaisir" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Deux Graces et un Plaisir</persName>
+                    <person xml:id="deux-graces" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Deux Graces</persName>
                     </person>
                     <person xml:id="arcas" sex="MALE">
                         <persName>Arcas</persName>
@@ -117,8 +117,8 @@
                     <person xml:id="un-berger" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Berger</persName>
                     </person>
-                    <person xml:id="un-berger-et-une-bergere" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Un Berger et une Bergere</persName>
+                    <person xml:id="une-bergere" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Une Bergere</persName>
                     </person>
                     <person xml:id="trois-bergers" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Trois Bergers</persName>
@@ -135,14 +135,11 @@
                     <person xml:id="une-autre-troyenne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Une Autre Troyenne</persName>
                     </person>
-                    <person xml:id="achille-et-polixene" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Achille et Polixene</persName>
-                    </person>
                     <person xml:id="un-grec" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Grec</persName>
                     </person>
-                    <person xml:id="un-grec-et-deux-troyennes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Un Grec et Deux Troyennes</persName>
+                    <person xml:id="deux-troyennes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Deux Troyennes</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -320,7 +317,7 @@
                         <l n="35">Hâtez-vous, secondez nos voeux ;</l>
                         <l n="36">Venez, et prêtez-nous vos grâces infinies.</l>
                     </sp>
-<sp who="#melpomeme_terpsicore">
+<sp who="#melpomeme #terpsicore">
                         <speaker>MELPOMÈME, TERPSICORE.</speaker>
                         <l n="37">Animez d'une ardeur nouvelle</l>
                         <l n="38">Venez remplir nos desseins,</l>
@@ -614,7 +611,7 @@
                         <l n="212">Préparez votre coeur</l>
                         <l n="213">Au plus parfait bonheur.</l>
                     </sp>
-<sp who="#deux-graces-et-un-plaisir">
+<sp who="#deux-graces #un-plaisir">
                         <speaker>DEUX GRÂCES ET UN PLAISIR.</speaker>
                         <l n="214">Quel mortel osa jamais prétendre</l>
                         <l n="215">Les soins qu'ici nous venons vous rendre ?</l>
@@ -635,7 +632,7 @@
                         <l n="224">Par notre heureux secours</l>
                         <l n="225">Vous en triompherez toujours.</l>
                     </sp>
-<sp who="#deux-graces-et-un-plaisir">
+<sp who="#deux-graces #un-plaisir">
                         <speaker>DEUX GRÂCES ET UN PLAISIR.</speaker>
                         <l n="226">Puissiez-vous par nos soins favorables</l>
                         <l n="227">Ne passer que des jours agréables !</l>
@@ -1188,7 +1185,7 @@
                         <l n="548">Bénissons à jamais</l>
                         <l n="549">Le généreux vainqueur, qui nous donne la paix.</l>
                     </sp>
-<sp who="#un-berger-et-une-bergere">
+<sp who="#un-berger #une-bergere">
                         <speaker>UN BERGER ET UNE BERGÈRE.</speaker>
                         <l n="550">Cet heureux jour doit nous charmer,</l>
                         <l n="551">Dans ces champs mille fleurs vont renaître,</l>
@@ -1202,7 +1199,7 @@
                         <l n="556">Que le ciel a fait seulement</l>
                         <l n="557">Pour le plaisir des coeurs sensibles.</l>
                     </sp>
-<sp who="#un-berger-et-une-bergere">
+<sp who="#un-berger #une-bergere">
                         <speaker>UN BERGER ET UNE BERGÈRE.</speaker>
                         <l n="558">Tristes bocages,</l>
                         <l n="559">Reprenez vos feuillages,</l>
@@ -1217,7 +1214,7 @@
                         <l n="564">Servez nous toujours</l>
                         <l n="565">D'asile à nos amours.</l>
                     </sp>
-<sp who="#un-berger-et-une-bergere">
+<sp who="#un-berger #une-bergere">
                         <speaker>UN BERGER ET UNE BERGÈRE.</speaker>
                         <l n="566">Paix adorable,</l>
                         <l n="567">Soyez toujours durable,</l>
@@ -1547,7 +1544,7 @@
                         <l n="767">Les feux de la Haine</l>
                         <l n="768">Cèdent à ceux de l'Amour.</l>
                     </sp>
-<sp who="#priam #achille-et-polixene">
+<sp who="#priam #achille #polixene">
                         <speaker>PRIAM, ACHILLE et POLIXÈNE.</speaker>
                         <l n="769">Commençons à jouir en ce jour,</l>
                         <l n="770">Des plaisirs que la Paix nous ramène,</l>
@@ -1588,7 +1585,7 @@
                         <speaker>LE CHOEUR.</speaker>
                         <l n="790">Tendres Amants, que vous serez heureux !</l>
                     </sp>
-<sp who="#un-grec-et-deux-troyennes">
+<sp who="#un-grec #deux-troyennes">
                         <speaker>UN GREC et DEUX TROYENNES.</speaker>
                         <l n="791">Chacun de vous connaît le prix de ce qu'il aime</l>
                         <l n="792">Et lui consacre tous ses voeux ;</l>

--- a/tei/carmontelle-petit-poucet.xml
+++ b/tei/carmontelle-petit-poucet.xml
@@ -69,12 +69,6 @@
                     <person xml:id="l-ogre" sex="MALE">
                         <persName>L'Ogre</persName>
                     </person>
-                    <person xml:id="le-petit-poucet_pierrot_javotte_janette" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Petit Poucet_pierrot_javotte_janette</persName>
-                    </person>
-                    <person xml:id="petit-poucet" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Petit Poucet</persName>
-                    </person>
                     <person xml:id="la-rentree" sex="MALE">
                         <persName>La Rentrée</persName>
                     </person>
@@ -1051,7 +1045,7 @@
 </p>
                         <stage type="pull/kneel">Il tire les enfants, qui se tiennent tous ensemble, et se jettent à genoux.</stage>
                     </sp>
-<sp who="#le-petit-poucet_pierrot_javotte_janette">
+<sp who="#le-petit-poucet #pierrot #javotte #janette">
                         <speaker>LES QUATRE ENFANTS.</speaker>
                         <p n="21">
 	<s n="1">Pardon , pardon.</s>
@@ -1765,7 +1759,7 @@
 	<s n="2">Mes pauvres enfants, où êtes-vous ?</s>
 </p>
                     </sp>
-<sp who="#le-petit-poucet_pierrot_javotte_janette">
+<sp who="#le-petit-poucet #pierrot #javotte #janette">
                         <speaker>LES QUATRE ENFANTS.</speaker>
                         <p n="16">
 	<s n="">Nous voilà, nous voilà. </s>
@@ -1799,7 +1793,7 @@
 	<s n="1">Petit Poucet, Javotte, n'avez-vous pas eu bien peur ?</s>
 </p>
                     </sp>
-<sp who="#petit-poucet #javotte">
+<sp who="#le-petit-poucet #javotte">
                         <speaker>PETIT POUCET, JAVOTTE.</speaker>
                         <p n="21">
 	<s n="1">Oh, pour cela oui, mon Papa.</s>

--- a/tei/carmontelle-pleureurs-d-homere.xml
+++ b/tei/carmontelle-pleureurs-d-homere.xml
@@ -51,17 +51,14 @@
                     <person xml:id="monsieur-delepine" sex="MALE">
                         <persName>Monsieur Delepine</persName>
                     </person>
-                    <person xml:id="delepine_desgrais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Delepine_desgrais</persName>
-                    </person>
-                    <person xml:id="monsieur-duchesne" sex="MALE">
-                        <persName>Monsieur Duchesne</persName>
-                    </person>
                     <person xml:id="delepine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Delepine</persName>
                     </person>
                     <person xml:id="desgrais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Desgrais</persName>
+                    </person>
+                    <person xml:id="monsieur-duchesne" sex="MALE">
+                        <persName>Monsieur Duchesne</persName>
                     </person>
                     <person xml:id="duchesne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Duchesne</persName>
@@ -356,7 +353,7 @@
 	<s n="1">Non, non, l'épopée !</s>
 </p>
                     </sp>
-<sp who="#delepine_desgrais">
+<sp who="#delepine #desgrais">
                         <speaker>ENSEMBLE.</speaker>
                         <p n="36">
 	<s n="1">Ah, ah, ah ! </s>

--- a/tei/chalmeton-a-jean-racine.xml
+++ b/tei/chalmeton-a-jean-racine.xml
@@ -45,8 +45,8 @@
         <profileDesc>
             <particDesc>
                 <listPerson>
-                    <person xml:id="empty-string" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Empty String</persName>
+                    <person xml:id="le-narrateur" sex="MALE">
+                        <persName>Le Narrateur</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -108,8 +108,7 @@
                 <head>À JEAN RACINE</head>
 <div type="scene" n="1">
                     <head/>
-<sp who="#empty-string">
-                        <speaker/>
+<sp who="#le-narrateur">
                         <ab type="1"><!--<poem>-->
 <lg n="1">
 	<l n="1">Racine, à toi ces vers ! Maître, à toi notre hommage !</l>

--- a/tei/clairville-siraudin-moreau-la-societe-du-doigt-dans-l-oeil.xml
+++ b/tei/clairville-siraudin-moreau-la-societe-du-doigt-dans-l-oeil.xml
@@ -74,9 +74,6 @@
                     <person xml:id="duverdier" sex="MALE">
                         <persName>Duverdier</persName>
                     </person>
-                    <person xml:id="louise-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Louise</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>

--- a/tei/colle-esperance.xml
+++ b/tei/colle-esperance.xml
@@ -52,9 +52,6 @@
                     <person xml:id="leandre" sex="MALE">
                         <persName>Léandre</persName>
                     </person>
-                    <person xml:id="la-parade-et-leandre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Parade et Leandre</persName>
-                    </person>
                     <person xml:id="l-esperance" sex="FEMALE">
                         <persName>L'Espérance</persName>
                     </person>
@@ -232,7 +229,7 @@
 	<s n="1">Donnez-vous bien de garde de la voir...</s>
 </p>
                     </sp>
-<sp who="#la-parade-et-leandre">
+<sp who="#la-parade #leandre">
                         <speaker>LA PARADE ET LÉANDRE, ensemble.</speaker>
                         <p n="5">
 	<s n="1">Eh ! </s>
@@ -270,7 +267,7 @@
                         <l n="34">Et je n'enfante,</l>
                         <l n="35">Que les soupçons.</l>
                     </sp>
-<sp who="#la-parade-et-leandre">
+<sp who="#la-parade #leandre">
                         <speaker>LA PARADE et LÉANDRE, ensemble.</speaker>
                         <l n="36">À ces traits nous vous connaissons.</l>
                         <stage type="title">Fin de l'Air : des Voyelles anciennes.</stage>
@@ -423,7 +420,7 @@
                         <l n="85">J'a-douicis jusqu'au tableau. </l>
                         <l n="86">Je fais montrer tout en beau.</l>
                     </sp>
-<sp who="#la-parade-et-leandre">
+<sp who="#la-parade #leandre">
                         <speaker>LA PARADE ET LÉANDRE, ensemble.</speaker>
                         <l n="87">Et - le montre tout en beau.</l>
                     </sp>
@@ -467,7 +464,7 @@
                         <speaker>LÉANDRE.</speaker>
                         <l n="109">De grâce, restez avec nous.</l>
                     </sp>
-<sp who="#la-parade-et-leandre">
+<sp who="#la-parade #leandre">
                         <speaker>LA PARADE ET LÉANDRE, ensemble.</speaker>
                         <l n="110">Dé-es-se, que ferions-nous, </l>
                         <l n="111">Sans vous.</l>

--- a/tei/corneillep-andromede.xml
+++ b/tei/corneillep-andromede.xml
@@ -82,9 +82,6 @@
                     <person xml:id="liriope" sex="FEMALE">
                         <persName>Liriope</persName>
                     </person>
-                    <person xml:id="page_liriope" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Page_liriope</persName>
-                    </person>
                     <person xml:id="timante" sex="MALE">
                         <persName>Timante</persName>
                     </person>
@@ -1154,7 +1151,7 @@
                         <speaker>LIRIOPE.</speaker>
                         <l n="573">Joignons nos voix pour bénir leur attente.</l>
                     </sp>
-<sp who="#page_liriope">
+<sp who="#page #liriope">
                         <speaker>PAGE et LIRIOPE.</speaker>
                         <l n="574">Andromède ce soir aura l'illustre époux</l>
                         <l n="575">Qui seul est digne d'elle, et dont seule elle est digne.</l>

--- a/tei/corneillet-illustres-ennemis.xml
+++ b/tei/corneillet-illustres-ennemis.xml
@@ -73,11 +73,14 @@
                     <person xml:id="don-ramire" sex="MALE">
                         <persName>Don Ramire</persName>
                     </person>
-                    <person xml:id="numer-brave" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numer Brave</persName>
+                    <person xml:id="brave-1er" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Brave 1er</persName>
                     </person>
-                    <person xml:id="numeme-brave" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numeme Brave</persName>
+                    <person xml:id="brave-2eme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Brave 2eme</persName>
+                    </person>
+                    <person xml:id="brave-3eme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Brave 3eme</persName>
                     </person>
                     <person xml:id="don-louis" sex="MALE">
                         <persName>Don Louis</persName>
@@ -2270,7 +2273,7 @@
 </div>
 <div type="scene" n="9">
                     <head>SCÈNE IX. Don Lope, Don Alvar, Trois Braves le poursuivant.</head>
-<sp who="#numer-brave">
+<sp who="#brave-1er">
                         <speaker>1er BRAVE.</speaker>
                         <l n="1093" part="F">Ta mort suivra la sienne.</l>
                     </sp>
@@ -2284,11 +2287,11 @@
                         <l n="1095" part="F">Quoi, trois contre un ! donnons, je suis à vous,</l>
                         <l n="1096" part="I">Mon cavalier, courage.</l>
                     </sp>
-<sp who="#numeme-brave">
+<sp who="#brave-2eme">
                         <speaker>2ème BRAVE.</speaker>
                         <l n="1096" part="F">Ô Dieu, les rudes coups !</l>
                     </sp>
-<sp who="#numeme-brave">
+<sp who="#brave-3eme">
                         <speaker>3ème BRAVE.</speaker>
                         <l n="1097" part="I">Ah ! Don Lope...</l>
                     </sp>
@@ -2296,7 +2299,7 @@
                         <speaker>DON LOPE.</speaker>
                         <l n="1097" part="F">Mon nom dans la bouche d'un lâche ?</l>
                     </sp>
-<sp who="#numeme-brave">
+<sp who="#brave-3eme">
                         <speaker>3ème BRAVE.</speaker>
                         <l n="1098" part="I">Sachez...</l>
                     </sp>
@@ -2304,7 +2307,7 @@
                         <speaker>DON LOPE.</speaker>
                         <l n="1098" part="F">J'ai déjà su ce qu'il faut que je sache.</l>
                     </sp>
-<sp who="#numeme-brave">
+<sp who="#brave-2eme">
                         <speaker>2ème BRAVE.</speaker>
                         <l n="1099">Craignant quelque disgrâce, évitons sa fureur.</l>
                     </sp>

--- a/tei/corneillet-inconnu.xml
+++ b/tei/corneillet-inconnu.xml
@@ -122,9 +122,6 @@
                     <person xml:id="aminte" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Aminte</persName>
                     </person>
-                    <person xml:id="alcidon_aminte" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Alcidon_aminte</persName>
-                    </person>
                     <person xml:id="un-maure" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Maure</persName>
                     </person>
@@ -3833,7 +3830,7 @@ La Décoration est une Montagne toute de rochers, aux côtés de laquelle on dé
                         <l n="1669">Qui ne craint point de perdre ce qu'il aime, </l>
                         <l n="1670">Sait peu ce que c'est que d'aimer. </l>
                     </sp>
-<sp who="#alcidon_aminte">
+<sp who="#alcidon #aminte">
                         <speaker>Tous deux ensemble.</speaker>
                         <l n="1671">Aimons-nous à jamais, aimons ; et si l'envie </l>
                         <l n="1672">Qui s'oppose à des feux si doux, </l>

--- a/tei/corneillet-medee.xml
+++ b/tei/corneillet-medee.xml
@@ -102,9 +102,6 @@
                     <person xml:id="creuse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Creuse</persName>
                     </person>
-                    <person xml:id="jason_creuse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Jason_creuse</persName>
-                    </person>
                     <person xml:id="choeur-des-captifs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Captifs</persName>
                     </person>
@@ -119,9 +116,6 @@
                     </person>
                     <person xml:id="trois-captifs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Trois Captifs</persName>
-                    </person>
-                    <person xml:id="oronte_medee" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Oronte_medee</persName>
                     </person>
                     <person xml:id="le-choeur-de-demons" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Choeur de Demons</persName>
@@ -1008,7 +1002,7 @@
                         <l n="436">De l'amour à nos coeurs faisons suivre l'empire :</l>
                         <l n="437">Le plaisir d'être aimé passe tous les plaisirs.</l>
                     </sp>
-<sp who="#jason_creuse">
+<sp who="#jason #creuse">
                         <speaker>JASON et CRÉÜSE.</speaker>
                         <l n="438">De l'amour à nos coeurs, faisons suivre l'empire :</l>
                         <l n="439">Le plaisir d'être aimé passe tous les plaisirs.</l>
@@ -1316,7 +1310,7 @@ Ou bien n'a-t-il ni coeur ni courage.</stage>
                         <l n="604">Qui l'aurait cru, que tant d'ingratitude</l>
                         <l n="605">Dût payer le beau feu qui règne dans mon coeur ? </l>
                     </sp>
-<sp who="#oronte_medee">
+<sp who="#oronte #medee">
                         <speaker>ORONTE et MÉDÉE.</speaker>
                         <l n="606">Qui l'aurait crû, que tant d'ingratitude</l>
                         <l n="607">Dût payer le beau feu qui règne dans mon coeur ?</l>
@@ -1335,7 +1329,7 @@ Ou bien n'a-t-il ni coeur ni courage.</stage>
                         <speaker>MÉDÉE.</speaker>
                         <l n="612">Quel plus sensible coup pouvais-je recevoir !</l>
                     </sp>
-<sp who="#oronte_medee">
+<sp who="#oronte #medee">
                         <speaker>Tous deux.</speaker>
                         <l n="613">Non, dans un coeur, quand l'amour est extrême,</l>
                         <l n="614">Rien n'approche du désespoir</l>
@@ -2267,7 +2261,7 @@ Ou bien n'a-t-il ni coeur ni courage.</stage>
                         <l n="1122">Pouvait elle mettre en usage</l>
                         <l n="1123">Un supplice plus propre à m'arracher le coeur ?</l>
                     </sp>
-<sp who="#jason_creuse">
+<sp who="#jason #creuse">
                         <speaker>TOUS DEUX.</speaker>
                         <l n="1124">Hélas ! Prêts d'être unis par les plus douces chaînes,</l>
                         <l n="1125">Faut-il nous voir séparés à jamais ? </l>
@@ -2280,7 +2274,7 @@ Ou bien n'a-t-il ni coeur ni courage.</stage>
                         <speaker>JASON.</speaker>
                         <l n="1127">Peut-on lancer sur moi de plus terribles traits ?</l>
                     </sp>
-<sp who="#jason_creuse">
+<sp who="#jason #creuse">
                         <speaker>TOUS DEUX.</speaker>
                         <l n="1128">Hélas ! Prêts d'être unis par les plus douces chaînes,</l>
                         <l n="1129">Faut-il nous voir séparés à jamais ?</l>

--- a/tei/coupigny-barre-piis-desfontaines-hommage-racine.xml
+++ b/tei/coupigny-barre-piis-desfontaines-hommage-racine.xml
@@ -90,9 +90,6 @@
                     <person xml:id="moliere" sex="MALE">
                         <persName>Molière</persName>
                     </person>
-                    <person xml:id="moliere_boileau" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Moliere_boileau</persName>
-                    </person>
                     <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Choeur</persName>
                     </person>
@@ -1565,7 +1562,7 @@
 	<s n="1">Je le sais bien ; mais le point est délicat : je n'ose m'expliquer davantage ; et je voudrais trouver une comparaison plus hardie que moi.</s>
 </p>
                     </sp>
-<sp who="#moliere_boileau">
+<sp who="#moliere #boileau">
                         <speaker>MOLIÈRE et BOILEAU.</speaker>
                         <p n="9">
 	<s n="1">Une comparaison ?</s>

--- a/tei/cubieres-palmezeaux-mort-de-moliere-3a.xml
+++ b/tei/cubieres-palmezeaux-mort-de-moliere-3a.xml
@@ -72,14 +72,8 @@
                     <person xml:id="le-semainier" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Semainier</persName>
                     </person>
-                    <person xml:id="isabelle-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Isabelle</persName>
-                    </person>
                     <person xml:id="angelique" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Angelique</persName>
-                    </person>
-                    <person xml:id="baron-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Baron</persName>
                     </person>
                     <person xml:id="cleante" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Cleante</persName>
@@ -1606,7 +1600,7 @@
 </div>
 <div type="scene" n="8">
                     <head>SCÈNE VIII. Isabelle, Baron.</head>
-<sp who="#isabelle- #angelique">
+<sp who="#isabelle #angelique">
                         <speaker>ISABELLE, faisant le rôle d'Angélique dans le Malade Imaginaire.</speaker>
                         <p n="1">
 	<s n="1">Ô Ciel ! </s>
@@ -1623,13 +1617,13 @@
 </p>
                         <stage type="imitate">Baron, faisant le rôle de Cléante.</stage>
                     </sp>
-<sp who="#baron- #cleante">
+<sp who="#baron #cleante">
                         <speaker>CLÉANTE.</speaker>
                         <p n="4">
 	<s n="1">Qu'avez-vous donc, belle Angélique, et quel malheur pleurez-vous ?</s>
 </p>
                     </sp>
-<sp who="#isabelle- #angelique">
+<sp who="#isabelle #angelique">
                         <speaker>ANGÉLIQUE.</speaker>
                         <p n="5">
 	<s n="1">Hélas ! </s>
@@ -1637,7 +1631,7 @@
 	<s n="3">Je pleure la mort de mon père.</s>
 </p>
                     </sp>
-<sp who="#baron- #cleante">
+<sp who="#baron #cleante">
                         <speaker>CLÉANTE.</speaker>
                         <p n="6">
 	<s n="1">Ô Ciel ! </s>
@@ -1647,7 +1641,7 @@
 	<s n="5">Après la demande que j'avais conjuré votre oncle de faire pour moi, je venais me présenter à lui, et tâcher par mes respects et par mes prières, de disposer son coeur à vous accorder à mes voeux.</s>
 </p>
                     </sp>
-<sp who="#isabelle- #angelique">
+<sp who="#isabelle #angelique">
                         <speaker>ANGÉLIQUE.</speaker>
                         <p n="7">
 	<s n="1">Ah ! </s>

--- a/tei/cubieres-palmezeaux-mort-de-moliere-4a.xml
+++ b/tei/cubieres-palmezeaux-mort-de-moliere-4a.xml
@@ -73,20 +73,11 @@
                     <person xml:id="le-semainier" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Semainier</persName>
                     </person>
-                    <person xml:id="isabelle-et-angelique" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Isabelle et Angelique</persName>
-                    </person>
-                    <person xml:id="baron-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Baron</persName>
+                    <person xml:id="angelique" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Angelique</persName>
                     </person>
                     <person xml:id="cleante" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Cleante</persName>
-                    </person>
-                    <person xml:id="isabelle-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Isabelle</persName>
-                    </person>
-                    <person xml:id="angelique" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Angelique</persName>
                     </person>
                     <person xml:id="le-docteur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Docteur</persName>
@@ -1638,7 +1629,7 @@
                         <l n="636">Il faut la bien savoir ; rien n'est plus nécessaire.</l>
                         <stage type="sit/location">Il s'assied entre-eux deux.</stage>
                     </sp>
-<sp who="#isabelle-et-angelique">
+<sp who="#isabelle #angelique">
                         <speaker>ISABELLE, jouant Angélique dans le Malade Imaginaire.</speaker>
                         <p n="1">
 	<s n="1">« Ô ciel ! </s>
@@ -1653,20 +1644,20 @@
 	<s n="1">« SCÈNE XXI, du Malade Imaginaire. Angélique, Cléante.</s>
 </p>
                     </sp>
-<sp who="#baron- #cleante">
+<sp who="#baron #cleante">
                         <speaker>BARON, jouant le rôle de Cléante.</speaker>
                         <p n="2">
 	<s n="1">Qu'avez-vous donc, belle Angélique, et quel malheur pleurez-vous ? </s>
 </p>
                     </sp>
-<sp who="#isabelle- #angelique">
+<sp who="#isabelle #angelique">
                         <speaker>ANGÉLIQUE.</speaker>
                         <p n="3">
 	<s n="1">Hélas ! </s>
 	<s n="2">Je pleure tout ce que, dans la vie, je pouvais perdre de plus cher et de plus précieux : je pleure la mort de mon père. </s>
 </p>
                     </sp>
-<sp who="#baron- #cleante">
+<sp who="#baron #cleante">
                         <speaker>CLÉANTE.</speaker>
                         <p n="4">
 	<s n="1">Ô ciel ! </s>
@@ -1693,7 +1684,7 @@
 	<s n="1">« Faire pour moi, je venais me présenter à lui, et tâcher, par mes respects et mes prières, de disposer son coeur à vous accorder à mes voeux.</s>
 </p>
                     </sp>
-<sp who="#isabelle- #angelique">
+<sp who="#isabelle #angelique">
                         <speaker>ANGÉLIQUE.</speaker>
                         <p n="7">
 	<s n="1">Ah ! </s>

--- a/tei/danchet-camille-reine-des-volsques.xml
+++ b/tei/danchet-camille-reine-des-volsques.xml
@@ -67,9 +67,6 @@
                     <person xml:id="flore" sex="FEMALE">
                         <persName>Flore</persName>
                     </person>
-                    <person xml:id="zephire-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Zephire</persName>
-                    </person>
                     <person xml:id="zephire" sex="MALE">
                         <persName>Zéphire</persName>
                     </person>
@@ -142,11 +139,11 @@
                     <person xml:id="la-pretresse-de-la-fortune" sex="FEMALE">
                         <persName>La Pretresse de la Fortune</persName>
                     </person>
-                    <person xml:id="la-pretresse-et-les-petits-choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Pretresse et les Petits Choeurs</persName>
-                    </person>
                     <person xml:id="la-pretresse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>La Pretresse</persName>
+                    </person>
+                    <person xml:id="les-petits-choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Petits Choeurs</persName>
                     </person>
                     <person xml:id="choeur-de-peuples" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur de Peuples</persName>
@@ -1602,7 +1599,7 @@ Seine, Choeurs de Peuples, Suite de Flore, Suite de Zephire;</head>
                         <l n="638">Tu te fais adorer de tout ce qui respire,</l>
                         <l n="639">Tu règles les destins de la Terre et des Mers.</l>
                     </sp>
-<sp who="#la-pretresse-et-les-petits-choeurs">
+<sp who="#la-pretresse #les-petits-choeurs">
                         <speaker>LA PRÊTRESSE ET LES PETITS CHOEURS.</speaker>
                         <stage type="explicit">Alternativement.</stage>
                         <l n="640">Le Matelot tremblant au milieu de l'orage</l>

--- a/tei/dancourt-cephale-procris.xml
+++ b/tei/dancourt-cephale-procris.xml
@@ -73,9 +73,6 @@
                     <person xml:id="un-faune" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Faune</persName>
                     </person>
-                    <person xml:id="un-faune-et-une-nymphe" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Un Faune et une Nymphe</persName>
-                    </person>
                     <person xml:id="procris" sex="FEMALE">
                         <persName>Procris</persName>
                     </person>
@@ -2261,7 +2258,7 @@
                         <l n="1115">Des plus tendres, des plus doux sons.</l>
                         <stage type="entrance">ENTRÉE</stage>
                     </sp>
-<sp who="#un-faune-et-une-nymphe">
+<sp who="#un-faune #une-nymphe">
                         <speaker>UN FAUNE ET UNE NYMPHE chantent.</speaker>
                         <l n="1116">Aimez, aimez, heureux Céphale,</l>
                         <l n="1117">Hâtez-vous d'être inconstant ;</l>

--- a/tei/dancourt-comedie-comediens.xml
+++ b/tei/dancourt-comedie-comediens.xml
@@ -59,9 +59,6 @@
                     <person xml:id="monsieur-grichardin" sex="MALE">
                         <persName>Monsieur Grichardin</persName>
                     </person>
-                    <person xml:id="lucile-et-angelique" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Lucile et Angelique</persName>
-                    </person>
                     <person xml:id="nicole" sex="FEMALE">
                         <persName>Nicole</persName>
                     </person>
@@ -136,9 +133,6 @@
                     </person>
                     <person xml:id="mathurine" sex="FEMALE">
                         <persName>Mathurine</persName>
-                    </person>
-                    <person xml:id="thibaut-et-mathurine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Thibaut et Mathurine</persName>
                     </person>
                     <person xml:id="le-chevalier" sex="MALE">
                         <persName>Le Chevalier</persName>
@@ -1140,7 +1134,7 @@
 	<s n="1">Oui, ma chère enfant, depuis notre mariage je suis galant et de meilleure humeur que je n'ai jamais été, et j'ai imaginé, pour vous faire plaisir, de vous donner ici ce soir une espèce de petit bal, une façon de petite fête.</s>
 </p>
                     </sp>
-<sp who="#lucile-et-angelique">
+<sp who="#lucile #angelique">
                         <speaker>LUCILE et ANGÉLIQUE.</speaker>
                         <p n="7">
 	<s n="1">Monsieur ? </s>
@@ -5950,7 +5944,7 @@
                         <l n="255">Et vous êtes mal adressés ;</l>
                         <l n="256">Mais puisqu'enfin l'Hymen vous unit de sa chaîne…</l>
                     </sp>
-<sp who="#thibaut-et-mathurine">
+<sp who="#thibaut #mathurine">
                         <speaker>THIBAUT et MATHURINE.</speaker>
                         <l n="257" part="I">Hélas oui !</l>
                     </sp>
@@ -5960,7 +5954,7 @@
                         <l n="258">Croyez-moi, tôt ou tard il faut que cela vienne,</l>
                         <l n="259">Et vous vous haïrez, ou vous vous haïssez.</l>
                     </sp>
-<sp who="#thibaut-et-mathurine">
+<sp who="#thibaut #mathurine">
                         <speaker>THIBAUT et MATHURINE.</speaker>
                         <l n="260" part="I">Je nous haïssons, nous ?</l>
                     </sp>

--- a/tei/dancourt-fees.xml
+++ b/tei/dancourt-fees.xml
@@ -87,9 +87,6 @@
                     <person xml:id="astur" sex="MALE">
                         <persName>Astur</persName>
                     </person>
-                    <person xml:id="inegilde-et-cleonide" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Inegilde et Cleonide</persName>
-                    </person>
                     <person xml:id="une-habitante-de-l-ile" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Une Habitante de L Ile</persName>
                     </person>
@@ -1217,7 +1214,7 @@
 	<s n="3">On vous demande en mariage, mes filles.</s>
 </p>
                     </sp>
-<sp who="#inegilde-et-cleonide">
+<sp who="#inegilde #cleonide">
                         <speaker>INEGILDE et CLEONIDE.</speaker>
                         <p n="4">
 	<s n="1">Ah, Seigneur !</s>

--- a/tei/dancourt-foire-saint-germain.xml
+++ b/tei/dancourt-foire-saint-germain.xml
@@ -95,8 +95,8 @@
                     <person xml:id="farfadel" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Farfadel</persName>
                     </person>
-                    <person xml:id="mademoiselle-de-kermonin-et-marotte" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Mademoiselle de Kermonin et Marotte</persName>
+                    <person xml:id="mademoiselle-de-kermonin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Mademoiselle de Kermonin</persName>
                     </person>
                     <person xml:id="tous" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous</persName>
@@ -3808,7 +3808,7 @@
 	<s n="1">Je le prends sous ma protection ; voilà qui est fini.</s>
 </p>
                     </sp>
-<sp who="#mademoiselle-de-kermonin-et-marotte">
+<sp who="#mademoiselle-de-kermonin #marotte">
                         <speaker>MADEMOISELLE DE KERMONIN et MAROTTE.</speaker>
                         <p n="34">
 	<s n="1">Comment, Monsieur ?</s>

--- a/tei/dancourt-impromptu-suresnes.xml
+++ b/tei/dancourt-impromptu-suresnes.xml
@@ -98,9 +98,6 @@
                     <person xml:id="silene" sex="MALE">
                         <persName>Silene</persName>
                     </person>
-                    <person xml:id="l-amour-et-thersandre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>L Amour et Thersandre</persName>
-                    </person>
                     <person xml:id="tous" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous</persName>
                     </person>
@@ -2691,7 +2688,7 @@
                         <l n="50">De la félicité parfaite </l>
                         <l n="51">C'est ici l'heureux séjour. </l>
                     </sp>
-<sp who="#philis #l-amour-et-thersandre">
+<sp who="#philis #l-amour #thersandre">
                         <speaker>PHILIS, L'AMOUR ET THERSANDRE.</speaker>
                         <l n="52">Avec Bacchus on passe tout le jour, </l>
                         <l n="53">On donne la nuit à l'Amour, </l>

--- a/tei/dancourt-metempsychose.xml
+++ b/tei/dancourt-metempsychose.xml
@@ -59,9 +59,6 @@
                     <person xml:id="thalie" sex="FEMALE">
                         <persName>Thalie</persName>
                     </person>
-                    <person xml:id="thalie-et-mercure" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Thalie et Mercure</persName>
-                    </person>
                     <person xml:id="un-thessalien" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Thessalien</persName>
                     </person>
@@ -676,7 +673,7 @@
                         <l n="192">Les Dieux exprès pour vous font naître </l>
                         <l n="193">Un nouveau genre de plaisirs. </l>
                     </sp>
-<sp who="#thalie-et-mercure">
+<sp who="#thalie #mercure">
                         <speaker>THALIE et MERCURE.</speaker>
                         <l n="194">Que la Jeunesse </l>
                         <l n="195">Dans cet heureux séjour, </l>
@@ -691,7 +688,7 @@
                         <l n="201">Que tous les mortels </l>
                         <l n="202">Doivent à leurs autels. </l>
                     </sp>
-<sp who="#thalie-et-mercure">
+<sp who="#thalie #mercure">
                         <speaker>THALIE et MERCURE.</speaker>
                         <l n="203">Que tout l'Univers se rassemble </l>
                         <l n="204">Sous leurs douces lois. </l>

--- a/tei/dancourt-moulin-de-javelle.xml
+++ b/tei/dancourt-moulin-de-javelle.xml
@@ -110,11 +110,11 @@
                     <person xml:id="le-marie" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Marie</persName>
                     </person>
-                    <person xml:id="les-mitrons-et-les-mitronnes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Les Mitrons et les Mitronnes</persName>
-                    </person>
                     <person xml:id="les-mitrons" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Mitrons</persName>
+                    </person>
+                    <person xml:id="les-mitronnes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Mitronnes</persName>
                     </person>
                     <person xml:id="tous-les-acteurs-et-actrices" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous les Acteurs et Actrices</persName>
@@ -4033,7 +4033,7 @@ Parties casuelles, droits et revenus éventuels ; et le bureau même où l'État
                         <l n="28">Humble salut au cousin George, </l>
                         <l n="29">De la part des cousins Mitrons.</l>
                     </sp>
-<sp who="#les-mitrons-et-les-mitronnes">
+<sp who="#les-mitrons #les-mitronnes">
                         <speaker>LES MITRONS et LES MITRONNES répètent.</speaker>
                         <l n="30">Humble salut au cousin George, </l>
                         <l n="31">De la part des cousins Mitrons.</l>

--- a/tei/dancourt-opera-de-village.xml
+++ b/tei/dancourt-opera-de-village.xml
@@ -77,14 +77,8 @@
                     <person xml:id="pierrot" sex="MALE">
                         <persName>Pierrot</persName>
                     </person>
-                    <person xml:id="pierrot_thibaut" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Pierrot_thibaut</persName>
-                    </person>
                     <person xml:id="claudine" sex="FEMALE">
                         <persName>Claudine</persName>
-                    </person>
-                    <person xml:id="pierrot_claudine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Pierrot_claudine</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -1881,7 +1875,7 @@
 	<s n="1">Masse.</s>
 </p>
                     </sp>
-<sp who="#pierrot_thibaut">
+<sp who="#pierrot #thibaut">
                         <speaker>TOUS DEUX. </speaker>
                         <l n="39">La bonne chose que le vin !</l>
                         <l n="40">Morgué, se peut-il qu'on s'en lasse ?</l>
@@ -1905,7 +1899,7 @@
                         <speaker>CLAUDINE.</speaker>
                         <l n="45">Vive aussi les filles, vive aussi les garçons.</l>
                     </sp>
-<sp who="#pierrot_claudine">
+<sp who="#pierrot #claudine">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="46">Les uns pour les autres, tretous je vivons,</l>
                         <l n="47">Et jamais par faute je ne chômerons.</l>

--- a/tei/dancourt-tuteur.xml
+++ b/tei/dancourt-tuteur.xml
@@ -62,9 +62,6 @@
                     <person xml:id="dorante" sex="MALE">
                         <persName>Dorante</persName>
                     </person>
-                    <person xml:id="monsieur-bernard_lucas" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Monsieur Bernard_lucas</persName>
-                    </person>
                     <person xml:id="maturine" sex="FEMALE">
                         <persName>Maturine</persName>
                     </person>
@@ -3076,7 +3073,7 @@ Fig. À tout hasard. [L]</note>
 	<s n="3">Par ma foi, voilà une jolie manière de guérir les soupçons d'un jaloux !</s> 
 </p>
                     </sp>
-<sp who="#monsieur-bernard_lucas">
+<sp who="#monsieur-bernard #lucas">
                         <speaker>MONSIEUR BERNARD et LUCAS derrière le Théâtre.</speaker>
                         <p n="7">
 	<s n="1">Haie, haie, haie, à l'aide.</s>

--- a/tei/diderot-fils-naturel.xml
+++ b/tei/diderot-fils-naturel.xml
@@ -65,9 +65,6 @@
                     <person xml:id="sylvestre" sex="MALE">
                         <persName>Sylvestre</persName>
                     </person>
-                    <person xml:id="dorval_clairville" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Dorval_clairville</persName>
-                    </person>
                     <person xml:id="andre" sex="MALE">
                         <persName>André</persName>
                     </person>
@@ -1621,7 +1618,7 @@
 	<s n="2">Vous m'en voyez encore toute tremblante ; et Rosalie en est à moitié morte.</s>
 </p>
                     </sp>
-<sp who="#dorval_clairville">
+<sp who="#dorval #clairville">
                         <speaker>DORVAL et CLAIRVILLE.</speaker>
                         <p n="2">
 	<s n="1">Rosalie !</s>
@@ -1842,7 +1839,7 @@
 	<s n="1">Je me meurs.</s>
 </p>
                     </sp>
-<sp who="#dorval_clairville">
+<sp who="#dorval #clairville">
                         <speaker>DORVAL et CLAIRVILLE.</speaker>
                         <p n="8">
 	<s n="1">Ô ciel ! </s>

--- a/tei/diderot-pere-de-famille.xml
+++ b/tei/diderot-pere-de-famille.xml
@@ -89,17 +89,8 @@
                     <person xml:id="deschamps" sex="MALE">
                         <persName>Deschamps</persName>
                     </person>
-                    <person xml:id="cecile_saint-albin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Cecile_saint Albin</persName>
-                    </person>
-                    <person xml:id="madame-hebert_monsieur-le-bon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Madame Hebert_monsieur le Bon</persName>
-                    </person>
                     <person xml:id="cecile-germeuil" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Cecile Germeuil</persName>
-                    </person>
-                    <person xml:id="saint-albin_cecile" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Saint Albin_cecile</persName>
                     </person>
                     <person xml:id="l-exempt" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>L Exempt</persName>
@@ -7024,7 +7015,7 @@
 	<s n="1">Le commandeur sait tout.</s>
 </p>
                     </sp>
-<sp who="#cecile_saint-albin">
+<sp who="#cecile #saint-albin">
                         <speaker>CÉCILE et SAINT-ALBIN, avec effroi.</speaker>
                         <p n="2">
 	<s n="1">Le commandeur sait tout !</s>
@@ -7882,7 +7873,7 @@
 	<s n="1">Arrêtez !</s>
 </p>
                     </sp>
-<sp who="#madame-hebert_monsieur-le-bon">
+<sp who="#madame-hebert #monsieur-le-bon">
                         <speaker>MADAME HÉBERT et MONSIEUR LE BON, en criant au commandeur, et en même temps que Saint-Albin.</speaker>
                         <p n="11">
 	<s n="1">Regardez-la.</s>
@@ -8013,7 +8004,7 @@
 	<s n="3">Voyez, vous n'avez pu vous éloigner de moi sans vous égarer.</s>
 </p>
                     </sp>
-<sp who="#saint-albin_cecile">
+<sp who="#saint-albin #cecile">
                         <speaker>SAINT-ALBIN et CÉCILE, en lui baisant les mains.</speaker>
                         <p n="32">
 	<s n="1">Ah, mon père ! </s>

--- a/tei/doigny-du-ponceau-antigone.xml
+++ b/tei/doigny-du-ponceau-antigone.xml
@@ -126,8 +126,6 @@
                     <role corresp="#un-enfant">UN ENFANT</role>, gui de Tirésias.</castItem>
 			<castItem>
                     <role corresp="#un-officier-de-l-armee-de-creon">UN OFFICIER DE L'ARMÉE DE CRÉON</role>.</castItem>
-			<castItem>
-                    <role corresp="#empty-string"/>.</castItem>
 		</castList>
 		<!--TODO: usage of set in correct place but with unknown attributes <set location="Thèbes" country="Grèce" periode="XVIème" gps="51.507, -0.127"/>-->
 </front>

--- a/tei/doigny-du-ponceau-antigone.xml
+++ b/tei/doigny-du-ponceau-antigone.xml
@@ -54,6 +54,12 @@
                     <person xml:id="creon" sex="MALE">
                         <persName>Créon</persName>
                     </person>
+                    <person xml:id="un-thebain" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Un Thebain</persName>
+                    </person>
+                    <person xml:id="plusieurs-ensemble" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Plusieurs Ensemble</persName>
+                    </person>
                     <person xml:id="l-officier" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>L Officier</persName>
                     </person>
@@ -1055,7 +1061,7 @@ CRÉON.
                         <speaker>CRÉON.</speaker>
                         <l n="">Vieillard, que me veux-tu ?</l>
                     </sp>
-<sp who="#tiresias,">
+<sp who="#tiresias">
                         <speaker>TIRÉSIAS,</speaker>
                         <l n="">Lui-même .</l>
                     </sp>
@@ -1155,7 +1161,7 @@ CRÉON.
                         <speaker>CRÉON.</speaker>
                         <l n="">Qu'aurais-je à redouter ?</l>
                     </sp>
-<sp who="#tiresias,-se-relevant-et-ramassant-toutes-ses-forces">
+<sp who="#tiresias">
                         <speaker>TIRÉSIAS, se relevant et ramassant toutes ses forces.</speaker>
                         <l n="">N'as-tu donc pas un fils ?</l>
                     </sp>

--- a/tei/donneau-de-vise-amours-du-soleil.xml
+++ b/tei/donneau-de-vise-amours-du-soleil.xml
@@ -98,11 +98,17 @@
                     <person xml:id="mercure" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Mercure</persName>
                     </person>
-                    <person xml:id="num-personne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Num Personne</persName>
+                    <person xml:id="personne-1" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Personne 1</persName>
                     </person>
-                    <person xml:id="num-furie" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Num Furie</persName>
+                    <person xml:id="personne-2" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Personne 2</persName>
+                    </person>
+                    <person xml:id="personne-3" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Personne 3</persName>
+                    </person>
+                    <person xml:id="furie-1" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Furie 1</persName>
                     </person>
                     <person xml:id="la-discorde" sex="FEMALE">
                         <persName>La Discorde</persName>
@@ -2283,7 +2289,7 @@
 </div>
 <div type="scene" n="5">
                     <head>SCÈNE V. La Princesse, Palmis, et trois Personnes qui sont sur les nuages.</head>
-<sp who="#num-personne">
+<sp who="#personne-1">
                         <speaker>1. PERSONNE.</speaker>
                         <l n="1097">Princesse, nous venons vous dire </l>
                         <l n="1098">Que tantôt Mercure et Pallas </l>
@@ -2294,14 +2300,14 @@
                         <l n="1103">Que vous devriez avoir déjà suivis, </l>
                         <l n="1104">Le Ciel vous fera voir des effets de sa haine. </l>
                     </sp>
-<sp who="#num-personne">
+<sp who="#personne-2">
                         <speaker>2. PERSONNE.</speaker>
                         <l n="1105">Vous devez renvoyer Apollon dans les Cieux, </l>
                         <l n="1106">Et ne prétendre plus à l'honneur de lui plaire ; </l>
                         <l n="1107">Ou bientôt contre vous les Dieux </l>
                         <l n="1108">Feront éclater leur colère. </l>
                     </sp>
-<sp who="#num-personne">
+<sp who="#personne-3">
                         <speaker>3. PERSONNE.</speaker>
                         <l n="1109">Reconnaissez quelles sont les bontés </l>
                         <l n="1110">De trois grandes Divinités </l>
@@ -2313,20 +2319,20 @@
                         <l n="1113">Quelles Divinités sont-ce donc que je vois, </l>
                         <l n="1114">Dont la tendre pitié s'intéresse pour moi ? </l>
                     </sp>
-<sp who="#num-personne">
+<sp who="#personne-1">
                         <speaker>1. PERSONNE.</speaker>
                         <l n="1115">Ne cherchez point à nous connaître, </l>
                         <l n="1116">Aux yeux de votre Amant nous craignons de paraître </l>
                         <l n="1117">Nous vous servirons mieux, en nous cachant ainsi, </l>
                         <l n="1118">Et nous ne voulons pas qu'il nous découvre ici. </l>
                     </sp>
-<sp who="#num-personne">
+<sp who="#personne-2">
                         <speaker>2. PERSONNE.</speaker>
                         <l n="1119">Suivez donc nos avis fidèles, </l>
                         <l n="1120">Que votre coeur s'y rende sans combats, </l>
                         <l n="1121">Ou redoutez des peines bien cruelles. </l>
                     </sp>
-<sp who="#num-personne">
+<sp who="#personne-1">
                         <speaker>1. PERSONNE.</speaker>
                         <l n="1122">Si nous n'étions pas immortelles, </l>
                         <l n="1123">Ces nuages ainsi ne nous soutiendraient pas. </l>
@@ -2341,7 +2347,7 @@
 </div>
 <div type="scene" n="6">
                     <head>SCÈNE VI. La Princesse, Palmis, Les Furies.</head>
-<sp who="#num-furie">
+<sp who="#furie-1">
                         <speaker>1. FURIE.</speaker>
                         <l n="1126">Arrêtez de la part du grand Maître des Dieux, </l>
                         <l n="1127">Et louez ses bontés extrêmes, </l>

--- a/tei/dorneval-fuzelier-lesage-arlequin-roi-des-ogres.xml
+++ b/tei/dorneval-fuzelier-lesage-arlequin-roi-des-ogres.xml
@@ -100,8 +100,8 @@
                     <person xml:id="la-française" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>La Française</persName>
                     </person>
-                    <person xml:id="les-ogres-et-les-ogresses" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Les Ogres et les Ogresses</persName>
+                    <person xml:id="les-ogres-et-les-ogresses" sex="UNKNOWN">
+                        <persName>Troupe d'Ogres et d'Ogresses</persName>
                     </person>
                     <person xml:id="premier-grivois" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Premier Grivois</persName>
@@ -182,7 +182,7 @@
 		<castItem>
                     <role corresp="#plusieurs-grivois">PLUSIEURS GRIVOIS</role>.</castItem>
 		<castItem>
-                    <role corresp="#troupe-d-ogres-et-d-ogresses">TROUPE D'OGRES ET D'OGRESSES</role>.</castItem>
+                    <role corresp="#les-ogres-et-les-ogresses">TROUPE D'OGRES ET D'OGRESSES</role>.</castItem>
 		<castItem>
                     <role corresp="#danseurs-et-danseuses-de-l-opera-de-paris">DANSEURS ET DANSEUSES DE L'OPÉRA DE PARIS</role>.</castItem>
 		<castItem>

--- a/tei/drault-la-boucle-d-oreille-de-josephine.xml
+++ b/tei/drault-la-boucle-d-oreille-de-josephine.xml
@@ -53,7 +53,7 @@
                     <person xml:id="flanchin" sex="MALE">
                         <persName>Flanchin</persName>
                     </person>
-                    <person xml:id="monsieur-mouquin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                    <person xml:id="monsieur-mouquin" sex="MALE">
                         <persName>Monsieur Mouquin</persName>
                     </person>
                     <person xml:id="polyte" sex="MALE">
@@ -109,7 +109,7 @@
 		<castItem>
                     <role corresp="#musardier">MUSARDIER</role>, vieux cocher d'omnibus, à la tête rubiconde et placide sous son chapeau plat en toile cirée qui laisse voir quelques mèches de cheveux blancs. Il a dans la bouche un antique brûle-gueule qui n'a jamais l'air allumé.</castItem>
 		<castItem>
-                    <role corresp="#empty-string">MONSIEUR MOUQUIN</role>, directeur de la police municipale, gros homme commun et braillard.</castItem>
+                    <role corresp="#monsieur-mouquin">MONSIEUR MOUQUIN</role>, directeur de la police municipale, gros homme commun et braillard.</castItem>
 	</castList>
 	<!--TODO: usage of set in correct place but with unknown attributes <set location="Paris" country="France" periode="XIXème" gps="48.856614, 2.352222">La scène se passe sur l'impériale de l'omnibus d'une ligne récemment disparue par suite de la concurrence du Métropolitain, la ligne de l'Hôtel_de_Ville à la Porte_Maillot. On est au dimanche où eut lieu la manifestation de la place de la Concorde en faveur des Soeurs. Il est une heure de l'après-midi. Les deux gardiens de la paix sont placés au bout de la banquette de gauche, près du cocher avec lequel ils font un bout de conversation. L'omnibus vient de quitter l'Hôtel de Ville et s'engage dans la rue de Rivoli.</set>-->
 	<note>Extrait de Jean Drault, "l'Impériale de L'omnibus", Paris, Flammarion, 1778, p. 5-17.</note>
@@ -275,7 +275,7 @@
 	<s n="2">M'semble avoir reconnu la couleur du riflard de Joséphine !</s>
 </p>
                     </sp>
-<sp who="#tamponnard">
+<sp who="#flanchin">
                         <speaker>FLANCHIN.</speaker>
                         <p n="22">
 	<s n="1">De Joséphine ?...</s>
@@ -306,7 +306,7 @@
 	<s n="2">Descendez vite...</s>
 </p>
                     </sp>
-<sp who="#monsieur-mouquin">
+<sp who="#musardier">
                         <speaker>MUSARDIER, flanquant un coup de fouet à un églantinard qui a saisi la bride de ses chevaux.</speaker>
                         <note type="L">Églantinard : Mot injurieux créé par le journaliste nationaliste et antidreyfusard Henri Rochefort en référence à l’églantine rouge, portée notamment lors des commémorations du 14 juillet 1900.</note>
                         <p n="27">
@@ -329,7 +329,7 @@
 	<s n="2">À la revoyure !</s>
 </p>
                     </sp>
-<sp who="#musardier">
+<sp who="#monsieur-mouquin">
                         <speaker>MONSIEUR MOUQUIN, à Tamponnard qui descend l'escalier de l'omnibus.</speaker>
                         <p n="30">
 	<s n="1">Un peu de moelleux avec ces gens-là, je vous prie, brigadier ! </s>
@@ -379,7 +379,7 @@
 	<s n="1">Une petite, boulotte, l'air décidé, qu'a des boucles d'oreilles en or, avec une pierre bleue, une turquoise, fausse... turellement...</s>
 </p>
                     </sp>
-<sp who="#monsieur-mouquin">
+<sp who="#flanchin">
                         <speaker>FLANCHIN.</speaker>
                         <p n="4">
 	<s n="1">Non ! </s>
@@ -440,7 +440,7 @@
 	<s n="1">Rouflaquet !...</s>
 </p>
                     </sp>
-<sp who="#flanchin">
+<sp who="#rouflaquet">
                         <speaker>ROUFLAQUET. </speaker>
                         <p n="12">
 	<s n="1">Polyte !... </s>
@@ -448,7 +448,7 @@
                         <stage type="touch/wave">Poignée de main fraternelle. Rouflaquet, qui est franc-maçon, gratte dans la main à Polyte.</stage>
                     </sp>
 <sp who="#polyte">
-                        <speaker>, retirant sa main.</speaker>
+                        <speaker>POLYTE, retirant sa main.</speaker>
                         <p n="13">
 	<s n="1">Tu me chatouilles la paume ! </s>
 	<s n="2">Finis donc ! </s>
@@ -571,7 +571,7 @@
 </p>
                         <stage type="get/throw">Il s'empare de Polyte qui veut se débarrasser des bijoux en les jetant dans la rue. Flanchin les lui prend des mains.</stage>
                     </sp>
-<sp who="#flanchin">
+<sp who="#rouflaquet">
                         <speaker>ROUFLAQUET, d'un ton imposant, à Flanchin.</speaker>
                         <p n="30">
 	<s n="1">Vous outrepassez votre autorité !... </s>

--- a/tei/drault-le-chapeau-de-monsieur-poiret.xml
+++ b/tei/drault-le-chapeau-de-monsieur-poiret.xml
@@ -94,7 +94,7 @@
 		<castItem>
                     <role corresp="#julien-barbotkau">JULIEN BARBOTKAU</role>, ouvrier poêlier-fumiste, d'un naturel gai, mais momentanément assombri par les difficultés qu'il éprouve à transporter à lui tout seul, sur l'omnibus, d'un bout à l'autre de Paris, une grille à coke, deux mètres de tuyau en tôle, une plaque de salamandre, deux chenets et sa boîte à outils.</castItem> 
 		<castItem>
-                    <role corresp="#empty-string">EMPLOYÉS, OUVRIERS, PETITES OUVRIÈRES, DEUX MARCHANDES AU PANIER</role>.</castItem>	
+                    <role corresp="#">EMPLOYÉS, OUVRIERS, PETITES OUVRIÈRES, DEUX MARCHANDES AU PANIER</role>.</castItem>	
 	</castList>
 	<!--TODO: usage of set in correct place but with unknown attributes <set location="Paris" country="France" periode="XIXème" gps="48.856614, 2.352222">La scène se passe sur l'impériale de l'énorme omnibus jaune Odéon-Batignolles. Il est huit heures et demie du matin. L'omnibus-catapulte descend la rue Fontaine avec un fracas considérable et va s'engager dans la rue Notre-Dame-de-Lorette, au grand trot de ses trois chevaux de timon que précède une maigre haridelle appelée cheval de renfort, par ironie sans doute, - ce genre d'animal domestique usité dans la Compagnie des omnibus semblant plus fait pour être remorqué lui-même que pour renforcer quoi que ce soit.</set>-->
 	<note>Extrait de Jean Drault, "l'Impériale de L'omnibus", Paris, Flammarion, 1778, p. 5-17.</note>

--- a/tei/du-ryer-argenis-poliarque.xml
+++ b/tei/du-ryer-argenis-poliarque.xml
@@ -73,11 +73,11 @@
                     <person xml:id="florice" sex="FEMALE">
                         <persName>Florice</persName>
                     </person>
-                    <person xml:id="soldats_1" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Soldats_1</persName>
+                    <person xml:id="soldats-1" sex="UNKNOWN">
+                        <persName>Première Troupe des Soldats</persName>
                     </person>
-                    <person xml:id="soldats_2" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Soldats_2</persName>
+                    <person xml:id="soldats-2" sex="UNKNOWN">
+                        <persName>Seconde Troupe des Soldats</persName>
                     </person>
                     <person xml:id="soldats" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Soldats</persName>
@@ -185,9 +185,9 @@
 	<castItem>
                     <role corresp="#sacrificateur">SACRIFICATEUR</role>.</castItem>
 	<castItem>
-                    <role corresp="#premiers-soldats">Première troupe des soldats</role> de Licogène.</castItem>
+                    <role corresp="#soldats-1">Première troupe des soldats</role> de Licogène.</castItem>
 	<castItem>
-                    <role corresp="#seconds-soldats">Seconde troupe des soldats</role> de Licogène.</castItem>
+                    <role corresp="#soldats-2">Seconde troupe des soldats</role> de Licogène.</castItem>
 	<castItem>
                     <role corresp="#soldats-de-meleandre">Soldats de Méléandre</role>.</castItem>
 </castList>
@@ -1696,7 +1696,7 @@
                         <speaker>ARGENIS.</speaker>
                         <l n="1062" part="F">Ils s'adressent à moi.</l>
                     </sp>
-<sp who="#soldats_1">
+<sp who="#soldats-1">
                         <speaker>PREMIÈRE TROUPE DES SOLDATS DE LICOGÈNE.</speaker>
                         <l n="1063" part="I">Madame vous viendrez.</l>
                     </sp>
@@ -1747,7 +1747,7 @@
                         <l n="1083">Ne me saurait fournir qu'un effort impuissant.</l>
                         <l n="1084" part="I">Grands Dieux !</l>
                     </sp>
-<sp who="#soldats_2">
+<sp who="#soldats-2">
                         <speaker>SECONDE TROUPE DES SOLDATS DE LICOGÈNE.</speaker>
                         <l n="1084" part="F">Ils ne sauraient empêcher que la Parque</l>
                         <l n="1085">Ne vous porte du lit en la mortelle barque.</l>
@@ -1757,7 +1757,7 @@
                         <l n="1086">Que faîtes vous cruels vos desseins odieux</l>
                         <l n="1087">Rencontreront ici la justice des dieux.</l>
                     </sp>
-<sp who="#soldats_2">
+<sp who="#soldats-2">
                         <speaker>SECONDE TROUPE DES SOLDATS DE LICOGÈNE.</speaker>
                         <l n="1088">Une fille ne peut nous vaincre par ses charmes.</l>
                     </sp>

--- a/tei/du-ryer-lisandre-caliste.xml
+++ b/tei/du-ryer-lisandre-caliste.xml
@@ -109,8 +109,8 @@
                     <person xml:id="juge" sex="MALE">
                         <persName>Le Juge</persName>
                     </person>
-                    <person xml:id="le_courrier" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le_courrier</persName>
+                    <person xml:id="le-courrier" sex="MALE">
+                        <persName>Le Courrier</persName>
                     </person>
                     <person xml:id="varasque" sex="MALE">
                         <persName>Varasque</persName>
@@ -3410,7 +3410,7 @@
                         <l n="1832">Mais un homme inconnu s'avance devers nous,</l>
                         <l n="1833">Il s'en faut informer, ami d'où venez-vous ?</l>
                     </sp>
-<sp who="#le_courrier">
+<sp who="#le-courrier">
                         <speaker>Le Courrier.</speaker>
                         <l n="1834" part="I">Je reviens de la cour.</l>
                     </sp>
@@ -3419,7 +3419,7 @@
                         <l n="1834" part="F">Hé bien quelles nouvelles ?</l>
                         <l n="1835">Qui tient le premier rang au nombre des plus belles ?</l>
                     </sp>
-<sp who="#le_courrier">
+<sp who="#le-courrier">
                         <speaker>Le Courrier.</speaker>
                         <l n="1836">Chacun selon l'amour qui le tient arrêté</l>
                         <l n="1837">Prodigue librement le prix de la beauté,</l>
@@ -3430,7 +3430,7 @@
                         <speaker>LISANDRE.</speaker>
                         <l n="1840" part="I">Que dit-on de Caliste ?</l>
                     </sp>
-<sp who="#le_courrier">
+<sp who="#le-courrier">
                         <speaker>Le Courrier.</speaker>
                         <l n="1840" part="F">On dit communément</l>
                         <l n="1841">Que Lucidan la voit en qualité d'amant.</l>
@@ -3444,7 +3444,7 @@
                         <l n="1842" part="F">Puis au siècle où nous sommes</l>
                         <l n="1843">La vérité se trouve aux paroles des hommes.</l>
                     </sp>
-<sp who="#le_courrier">
+<sp who="#le-courrier">
                         <speaker>Le Courrier.</speaker>
                         <l n="1844">Et je crois que l'Hymen unirait leurs amours</l>
                         <l n="1845">Si Varasque n'eut pas interrompu leurs cours.</l>
@@ -3453,7 +3453,7 @@
                         <speaker>LISANDRE.</speaker>
                         <l n="1846" part="I">Comment cela ?</l>
                     </sp>
-<sp who="#le_courrier">
+<sp who="#le-courrier">
                         <speaker>Le Courrier.</speaker>
                         <l n="1846" part="F">Varasque ennemi de Lisandre</l>
                         <l n="1847">Venge par un combat le trépas de Cléandre :</l>

--- a/tei/dufresny-double-veuvage.xml
+++ b/tei/dufresny-double-veuvage.xml
@@ -72,9 +72,6 @@
                     <person xml:id="gusmand" sex="MALE">
                         <persName>Gusmand</persName>
                     </person>
-                    <person xml:id="la-suivante_gusmand" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Suivante_gusmand</persName>
-                    </person>
                     <person xml:id="la-veuve" sex="FEMALE">
                         <persName>La Veuve</persName>
                     </person>
@@ -1540,7 +1537,7 @@
                         <speaker>GUSMAND.</speaker>
                         <l n="42">Que de défauts il avait en partage.</l>
                     </sp>
-<sp who="#la-suivante_gusmand">
+<sp who="#la-suivante #gusmand">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="43">Pleurons, pleurons les malheurs du Veuvage.</l>
                         <l n="44">Chantons, chantons les douceurs du Veuvage.</l>

--- a/tei/dufresny-joueuse.xml
+++ b/tei/dufresny-joueuse.xml
@@ -69,9 +69,6 @@
                     <person xml:id="la-joueuse" sex="FEMALE">
                         <persName>Madame Orgon</persName>
                     </person>
-                    <person xml:id="lisette_la-joueuse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Lisette_la Joueuse</persName>
-                    </person>
                     <person xml:id="le-chevalier" sex="MALE">
                         <persName>Le Chevalier</persName>
                     </person>
@@ -2084,7 +2081,7 @@
 	<s n="1">Il passe encore.</s>
 </p>
                     </sp>
-<sp who="#lisette_la-joueuse">
+<sp who="#lisette #la-joueuse">
                         <speaker>LISETTE et LA JOUEUSE toutes deux ensemble.</speaker>
                         <p n="28">
 	<s n="">Il passe, il passe.</s>

--- a/tei/dufresny-reconciliation-normande.xml
+++ b/tei/dufresny-reconciliation-normande.xml
@@ -69,9 +69,6 @@
                     <person xml:id="le-chevalier" sex="MALE">
                         <persName>Le Chevalier</persName>
                     </person>
-                    <person xml:id="falaise_nerine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Falaise_nerine</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -2885,7 +2882,7 @@
                         <speaker>FALAISE, haut à part.</speaker>
                         <l n="953" part="M">Ouf. </l>
                     </sp>
-<sp who="#falaise_nerine">
+<sp who="#falaise #nerine">
                         <speaker>FALAISE et NÉRINE ensemble en s'approchant.</speaker>
                         <l n="953" part="M">Ouf ! </l>
                     </sp>

--- a/tei/dufresny-regnard-chinois.xml
+++ b/tei/dufresny-regnard-chinois.xml
@@ -78,9 +78,6 @@
                     <person xml:id="arlequin" sex="MALE">
                         <persName>Arlequin</persName>
                     </person>
-                    <person xml:id="roquillard_colombine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Roquillard_colombine</persName>
-                    </person>
                     <person xml:id="la-rhetorique" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>La Rhetorique</persName>
                     </person>
@@ -1365,7 +1362,7 @@
 	<s n="1">Je suis persuadé que la suivante est une carogne ; mais je lui donnerai tant de coups d'étrivières...</s>
 </p>
                     </sp>
-<sp who="#roquillard_colombine">
+<sp who="#roquillard #colombine">
                         <speaker>ROQUILLARD et COLOMBINE.</speaker>
                         <p n="9">
 	<s n="1">Monsieur, monsieur...</s>

--- a/tei/duvert-huron.xml
+++ b/tei/duvert-huron.xml
@@ -107,9 +107,6 @@
                     <person xml:id="toutes-les-femmes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Toutes les Femmes</persName>
                     </person>
-                    <person xml:id="kerkabon-et-mademoiselle-kerkabon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Kerkabon et Mademoiselle Kerkabon</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -2473,7 +2470,7 @@ Kerkabon, Le Huron, Mademoiselle Saint-Yves.</head>
 	<s n="4">Quoique je ne les aie jamais vus ; c'est mon père qui m'en a embelli à ma naissance.</s>
 </p>
                     </sp>
-<sp who="#kerkabon-et-mademoiselle-kerkabon">
+<sp who="#kerkabon #mademoiselle-kerkabon">
                         <speaker>KERKABON et MADEMOISELLE KERKABON.</speaker>
                         <p n="6">
 	<s n="1">Son père !</s>

--- a/tei/duvert-xavier-odeina.xml
+++ b/tei/duvert-xavier-odeina.xml
@@ -86,9 +86,6 @@
                     <person xml:id="d-harvillihers" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>D Harvillihers</persName>
                     </person>
-                    <person xml:id="medwin-et-les-matelots" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Medwin et les Matelots</persName>
-                    </person>
                     <person xml:id="les-matelots" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Matelots</persName>
                     </person>
@@ -2679,7 +2676,7 @@ des sentiments différents.</stage>
                         <l n="229">Les armes des forêts ;</l>
                         <l n="230">De ce départ déposez les apprêts.</l>
                     </sp>
-<sp who="#medwin-et-les-matelots">
+<sp who="#medwin #les-matelots">
                         <speaker>MEDWIN et LES MATELOTS.</speaker>
                         <l n="231">Adieu donc ! D'heureux jours,</l>
                         <l n="232">Et puissent les amours</l>

--- a/tei/fournier-racine-a-uzes.xml
+++ b/tei/fournier-racine-a-uzes.xml
@@ -57,9 +57,6 @@
                     <person xml:id="monsingre" sex="MALE">
                         <persName>Monsingre</persName>
                     </person>
-                    <person xml:id="georges-et-courtes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Georges et Courtes</persName>
-                    </person>
                     <person xml:id="jeanne" sex="FEMALE">
                         <persName>Jeanne</persName>
                     </person>
@@ -444,7 +441,7 @@
                         <speaker>COURTÈS.</speaker>
                         <l n="171" part="F">A-t-il fui ? Mauvais cas !</l>
                     </sp>
-<sp who="#georges-et-courtes">
+<sp who="#georges #courtes">
                         <speaker>GEORGES ET COURTÈS, ensemble.</speaker>
                         <l n="172" part="I">Répondez !...</l>
                     </sp>

--- a/tei/fuzelier-lesage-tableau-du-mariage.xml
+++ b/tei/fuzelier-lesage-tableau-du-mariage.xml
@@ -81,9 +81,6 @@
                     <person xml:id="madame-pepin" sex="FEMALE">
                         <persName>Madame Pepin</persName>
                     </person>
-                    <person xml:id="olivette_arlequin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Olivette_arlequin</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -1358,7 +1355,7 @@
                         <l n="140">Nous n'aimons qu'à sauter, qu'à rire ;</l>
                         <stage type="jump/fall">Il tombe en voulant sauter.</stage>
                     </sp>
-<sp who="#olivette_arlequin">
+<sp who="#olivette #arlequin">
                         <speaker>OLIVETTE et ARLEQUIN, le relevant.</speaker>
                         <p n="6">
 	<s n="1">Talaleri, talaleri, talalerire.</s>

--- a/tei/garnier-bradamante.xml
+++ b/tei/garnier-bradamante.xml
@@ -74,8 +74,8 @@
                     <person xml:id="hippalque" sex="MALE">
                         <persName>Hippalque</persName>
                     </person>
-                    <person xml:id="la_montagne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La_montagne</persName>
+                    <person xml:id="la-montagne" sex="MALE">
+                        <persName>La Montagne</persName>
                     </person>
                     <person xml:id="marphise" sex="MALE">
                         <persName>Marphise</persName>
@@ -1941,7 +1941,7 @@
                 <head>ACTE IV</head>
 <div type="scene" n="1">
                     <head>SCÈNE I. La Montagne, Aymon, Beatrix.</head>
-<sp who="#la_montagne">
+<sp who="#la-montagne">
                         <speaker>LA MONTAGNE.</speaker>
                         <l n="1013">Qui eut jamais pensé que ce prince de Grèce</l>
                         <l n="1014">Eut en lui tant de coeur, tant de force et d'adresse,</l>
@@ -1954,7 +1954,7 @@
                         <speaker>AYMON.</speaker>
                         <l n="1019" part="I">Que dit ce gentilhomme ?</l>
                     </sp>
-<sp who="#la_montagne">
+<sp who="#la-montagne">
                         <speaker>LA MONTAGNE.</speaker>
                         <l n="1019" part="F">Il est César de nom,</l>
                         <l n="1020">Mais il l'est maintenant de fait et de renom.</l>
@@ -1963,7 +1963,7 @@
                         <speaker>AYMON.</speaker>
                         <l n="1021">C'est de Léon qu'il parle, écoutons-le un peu dire.</l>
                     </sp>
-<sp who="#la_montagne">
+<sp who="#la-montagne">
                         <speaker>LA MONTAGNE.</speaker>
                         <l n="1022">Chacun lui fait honneur, tout le monde l'admire.</l>
                     </sp>
@@ -1971,7 +1971,7 @@
                         <speaker>AYMON.</speaker>
                         <l n="1023">Il a doncques vaincu ; nous voilà hors d'ennui.</l>
                     </sp>
-<sp who="#la_montagne">
+<sp who="#la-montagne">
                         <speaker>LA MONTAGNE.</speaker>
                         <l n="1024">Certe il est digne d'elle autant qu'elle de lui.</l>
                     </sp>
@@ -1984,7 +1984,7 @@
                         <l n="1025" part="F">J'en ai fort grande envie.</l>
                         <l n="1026">Et quoi ? Notre bataille est-elle jà finie ?</l>
                     </sp>
-<sp who="#la_montagne">
+<sp who="#la-montagne">
                         <speaker>LA MONTAGNE.</speaker>
                         <l n="1027" part="I">C'en est fait.</l>
                     </sp>
@@ -1992,7 +1992,7 @@
                         <speaker>AYMON.</speaker>
                         <l n="1027" part="M">Et qui gagne ?</l>
                     </sp>
-<sp who="#la_montagne">
+<sp who="#la-montagne">
                         <speaker>LA MONTAGNE.</speaker>
                         <l n="1027" part="F">Ils ont égal honneur.</l>
                     </sp>
@@ -2000,7 +2000,7 @@
                         <speaker>AYMON.</speaker>
                         <l n="1028" part="I">Égal ? comment cela ?</l>
                     </sp>
-<sp who="#la_montagne">
+<sp who="#la-montagne">
                         <speaker>LA MONTAGNE.</speaker>
                         <l n="1028" part="F">Mais Léon est vainqueur.</l>
                     </sp>
@@ -2017,7 +2017,7 @@
                         <l n="1030">Je ne saurais ouïr chose qui tant me plaise!</l>
                         <l n="1031">Mais de grâce contez comme tout s'est passé.</l>
                     </sp>
-<sp who="#la_montagne">
+<sp who="#la-montagne">
                         <speaker>LA MONTAGNE.</speaker>
                         <l n="1032">Autour du camp était tout le peuple amassé,</l>
                         <l n="1033">Et Charles devisait avec les preux de France,</l>
@@ -2110,7 +2110,7 @@
                         <speaker>AYMON.</speaker>
                         <l n="1118" part="I">Et que dit l'Empereur ?</l>
                     </sp>
-<sp who="#la_montagne">
+<sp who="#la-montagne">
                         <speaker>LA MONTAGNE.</speaker>
                         <l n="1118" part="F">Qu'il entend qu'il l'épouse.</l>
                     </sp>

--- a/tei/garniert-joueuses.xml
+++ b/tei/garniert-joueuses.xml
@@ -48,14 +48,11 @@
                     <person xml:id="madame-varseuil" sex="FEMALE">
                         <persName>Madame Varseuil</persName>
                     </person>
-                    <person xml:id="louison-et-henriette" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Louison et Henriette</persName>
+                    <person xml:id="louison" sex="FEMALE">
+                        <persName>Louison</persName>
                     </person>
                     <person xml:id="henriette" sex="FEMALE">
                         <persName>Henriette</persName>
-                    </person>
-                    <person xml:id="louison" sex="FEMALE">
-                        <persName>Louison</persName>
                     </person>
                     <person xml:id="madame-verseuil" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Madame Verseuil</persName>
@@ -164,7 +161,7 @@
 	<s n="1">Louison... Henriette...</s>
 </p>
                     </sp>
-<sp who="#louison-et-henriette">
+<sp who="#louison #henriette">
                         <speaker>LOUISON et HENRIETTE, du dedans.</speaker>
                         <p n="5">
 	<s n="1">Ma chère mère.</s>

--- a/tei/garniert-marianne.xml
+++ b/tei/garniert-marianne.xml
@@ -66,9 +66,6 @@
                     <person xml:id="le-laquais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Laquais</persName>
                     </person>
-                    <person xml:id="empty-string" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Empty String</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -840,7 +837,7 @@ transport.</stage>
 	<s n="1">Je m'en vais donc vous apporter tout ce qu'il faut.</s>
 </p>
                     </sp>
-<sp who="#mademoiselle-la-varenne #empty-string">
+<sp who="#mademoiselle-la-varenne #">
                         <speaker>MADEMOISELLE LA VARENNE, avec aigreur.</speaker>
                         <p n="8">
 	<s n="1">Eh, non ; vous êtes trop obligeante. </s>

--- a/tei/garniert-saignee.xml
+++ b/tei/garniert-saignee.xml
@@ -57,8 +57,8 @@
                     <person xml:id="dubois" sex="MALE">
                         <persName>Dubois</persName>
                     </person>
-                    <person xml:id="le-marquis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Marquis</persName>
+                    <person xml:id="le-marquis" sex="MALE">
+                        <persName>Le Marquis Dorival</persName>
                     </person>
                     <person xml:id="monsieur-dormel" sex="MALE">
                         <persName>Monsieur Dormel</persName>
@@ -66,11 +66,8 @@
                     <person xml:id="dormel-fils" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Dormel Fils</persName>
                     </person>
-                    <person xml:id="monsieur-et-madame-dormel" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Monsieur et Madame Dormel</persName>
-                    </person>
-                    <person xml:id="le-comte" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Comte</persName>
+                    <person xml:id="le-comte" sex="MALE">
+                        <persName>Le Comte de Sainbon</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -118,11 +115,11 @@
 		<castItem>
                     <role corresp="#le-petit-dormel">LE PETIT DORMEL</role>, âgé de six ans.</castItem>
 		<castItem>
-                    <role corresp="#le-marquis-dorival">LE MARQUIS DORIVAL</role>.</castItem>
+                    <role corresp="#le-marquis">LE MARQUIS DORIVAL</role>.</castItem>
 		<castItem>
                     <role corresp="#dubois">DUBOIS</role>, Valet de chambre du Marquis.</castItem>
 		<castItem>
-                    <role corresp="#le-comte-de-sainbon">LE COMTE DE SAINBON</role>.</castItem>
+                    <role corresp="#le-comte">LE COMTE DE SAINBON</role>.</castItem>
 		<castItem>
                     <role corresp="#un-laquais">UN LAQUAIS du Comte</role>, Personnage muet.</castItem>
    </castList>
@@ -828,7 +825,7 @@ eft-ce que nous ne dînons pas aujourd'hui ?</s>
 	<s n="2">C'était pour vous donner du pain.</s>
 </p>
                     </sp>
-<sp who="#monsieur-et-madame-dormel">
+<sp who="#monsieur-dormel #madame-dormel">
                         <speaker>MONSIEUR et MADAME DORMEL.</speaker>
                         <p n="9">
 	<s n="1">Ah, mon fils !</s>

--- a/tei/gautiert-une-larme-du-diable.xml
+++ b/tei/gautiert-une-larme-du-diable.xml
@@ -152,9 +152,6 @@
                     <person xml:id="gibonne" sex="FEMALE">
                         <persName>Gibonne</persName>
                     </person>
-                    <person xml:id="alix-et-blancheflor" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Alix et Blancheflor</persName>
-                    </person>
                     <person xml:id="l-eau-benite" sex="UNKNOWN">
                         <persName>L'Eau Bénite</persName>
                     </person>
@@ -1251,7 +1248,7 @@
 	<s n="1">Je suis aveugle et paralytique.</s>
 </p>
                     </sp>
-<sp who="#alix-et-blancheflor">
+<sp who="#alix #blancheflor">
                         <speaker>ALIX ET BLANCHEFLOR.</speaker>
                         <p n="12">
 	<s n="1">Tenez, ma bonne femme, voilà pour vous.</s>

--- a/tei/genlis-cloison.xml
+++ b/tei/genlis-cloison.xml
@@ -2311,7 +2311,7 @@
 </div>
 <div type="scene" n="17">
                     <head>SCÈNE XVII.</head>
-<sp who="#sophie,-elle-reste-immobile-a-sa-place,-et-regarde-la-cloison">
+<sp who="#sophie">
                         <speaker>SOPHIE, elle reste immobile à sa place, et regarde la Cloison. </speaker>
                         <p n="1">
 	<s n="1">Il est là !... </s>

--- a/tei/genlis-retour-de-tobie.xml
+++ b/tei/genlis-retour-de-tobie.xml
@@ -59,11 +59,11 @@
                     <person xml:id="anne" sex="FEMALE">
                         <persName>Anne, Femme du Vieux Tobie</persName>
                     </person>
-                    <person xml:id="troupes-de-voisins-et-voisines" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Troupes de Voisins et Voisines</persName>
+                    <person xml:id="troupe-de-voisins-et-voisines" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Troupe de Voisins et Voisines</persName>
                     </person>
-                    <person xml:id="sophar-et-les-voisins" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Sophar et les Voisins</persName>
+                    <person xml:id="les-voisins" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Voisins</persName>
                     </person>
                     <person xml:id="le-jeune-tobie" sex="MALE">
                         <persName>Le Jeune Tobie</persName>
@@ -698,7 +698,7 @@
 </div>
 <div type="scene" n="7">
                     <head>SCÈNE VII. Anne, Tobie, Éliphas, Sophar.</head>
-<sp who="#troupes-de-voisins-et-voisines">
+<sp who="#troupe-de-voisins-et-voisines">
                         <speaker>TROUPES DE VOISINS ET VOISINES.</speaker>
                         <p n="1">
 	<s n="1">Ils entrent tous en tumulte, et en s'écriant : Il est arrivé ! il est arrivé !...</s>
@@ -764,7 +764,7 @@
 </p>
                         <stage type="hugh/pull">Elle prend Éliphas par le bras et l'entraîne.</stage>
                     </sp>
-<sp who="#sophar-et-les-voisins">
+<sp who="#sophar #les-voisins">
                         <speaker>SOPHAR et les voisins.</speaker>
                         <p n="11">
 	<s n="1">Suivons-la... </s>

--- a/tei/genlis-tendresse-maternelle.xml
+++ b/tei/genlis-tendresse-maternelle.xml
@@ -307,7 +307,7 @@
 	<s n="3">C'est une étourdie... une coquette...</s>
 </p>
                     </sp>
-<sp who="#victoire,-en-riant">
+<sp who="#victoire">
                         <speaker>VICTOIRE, en riant. </speaker>
                         <p n="28">
 	<s n="1">Vous lui en voulez de plus loin... </s>

--- a/tei/gonnet-clementine.xml
+++ b/tei/gonnet-clementine.xml
@@ -70,8 +70,11 @@
                     <person xml:id="une-voix" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Une Voix</persName>
                     </person>
-                    <person xml:id="numeme-solo" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numeme Solo</persName>
+                    <person xml:id="solo-2eme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Solo 2eme</persName>
+                    </person>
+                    <person xml:id="solo-5eme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Solo 5eme</persName>
                     </person>
                     <person xml:id="la-commissionnaire" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>La Commissionnaire</persName>
@@ -452,14 +455,14 @@
                         <l n="100">Accordez à nos coeurs</l>
                         <l n="101">Vos plus douces faveurs.</l>
                     </sp>
-<sp who="#numeme-solo">
+<sp who="#solo-2eme">
                         <speaker>2ème SOLO.</speaker>
                         <l n="102">Ô vous dont on connaît les vertus, la science,</l>
                         <l n="103">Vous savez que l'enfance </l>
                         <l n="104">A besoin de secours,</l>
                         <l n="105">Protégez la toujours.</l>
                     </sp>
-<sp who="#numeme-solo">
+<sp who="#solo-5eme">
                         <speaker>5ème SOLO.</speaker>
                         <l n="106">Ô vous à qui nos coeurs ne demandent qu'à plaire,</l>
                         <l n="107">Aimable et tendre Père,</l>

--- a/tei/goullinet-trois-aveugles.xml
+++ b/tei/goullinet-trois-aveugles.xml
@@ -63,17 +63,11 @@
                     <person xml:id="lisidor" sex="MALE">
                         <persName>Lisidor</persName>
                     </person>
-                    <person xml:id="jerome-et-les-deux-aveugles" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Jerome et les Deux Aveugles</persName>
-                    </person>
                     <person xml:id="la-piquette" sex="MALE">
                         <persName>La Piquette</persName>
                     </person>
                     <person xml:id="le-garçon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Garçon</persName>
-                    </person>
-                    <person xml:id="la-piquette-et-le-garçon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Piquette et le Garçon</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -1260,7 +1254,7 @@
 	<s n="1">Mais ais oui, c'est du meilleur qu'il nous faut.</s>
 </p>
                     </sp>
-<sp who="#jerome-et-les-deux-aveugles">
+<sp who="#jerome #les-deux-aveugles">
                         <speaker>JÉROME et LES DEUX AVEUGLES.</speaker>
                         <p n="19">
 	<s n="1">Allons, eh ! </s>
@@ -2049,7 +2043,7 @@
 	<s n="1">Je e défie bien qu'on me fasse payer.</s>
 </p>
                     </sp>
-<sp who="#la-piquette-et-le-garçon">
+<sp who="#la-piquette #le-garçon">
                         <speaker>LA PIQUETTE et LE GARÇON.</speaker>
                         <p n="25">
 	<s n="1">Ah ! </s>

--- a/tei/gueullette-chaste-isabelle.xml
+++ b/tei/gueullette-chaste-isabelle.xml
@@ -52,14 +52,11 @@
                     <person xml:id="isabelle" sex="FEMALE">
                         <persName>Isabelle</persName>
                     </person>
-                    <person xml:id="villebrequin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Villebrequin</persName>
+                    <person xml:id="villebrequin" sex="MALE">
+                        <persName>Monsieur Villebrequin</persName>
                     </person>
-                    <person xml:id="cassandre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Cassandre</persName>
-                    </person>
-                    <person xml:id="cassandre-et-villebrequin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Cassandre et Villebrequin</persName>
+                    <person xml:id="cassandre" sex="MALE">
+                        <persName>Monsieur Cassandre</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -108,9 +105,9 @@
 		<castItem>
                     <role corresp="#isabelle">ISABELLE</role>, amante de Léandre.</castItem>
 		<castItem>
-                    <role corresp="#monsieur-villebrequin">MONSIEUR VILLEBREQUIN</role>, vieillard.</castItem>
+                    <role corresp="#villebrequin">MONSIEUR VILLEBREQUIN</role>, vieillard.</castItem>
 		<castItem>
-                    <role corresp="#monsieur-cassandre">MONSIEUR CASSANDRE</role>, vieillard.</castItem>
+                    <role corresp="#cassandre">MONSIEUR CASSANDRE</role>, vieillard.</castItem>
 	</castList>
 	<!--TODO: usage of set in correct place but with unknown attributes <set location="France" country="France" periode="XVIIIème" gps="(N/A)"/>-->
 	<note>Tiré de "Théâtre des Boulevards ou Recueil des parades. Tome premier" pp 51-73</note>
@@ -892,7 +889,7 @@
 	<s n="1">Qui va là ?</s>
 </p>
                     </sp>
-<sp who="#cassandre-et-villebrequin">
+<sp who="#cassandre #villebrequin">
                         <speaker>CASSANDRE et VILLEBREQUIN, en même temps.</speaker>
                         <p n="4">
 	<s n="1">C'est moi, charmante Isabelle...</s>
@@ -904,7 +901,7 @@
 	<s n="1">Qui vous ?</s>
 </p>
                     </sp>
-<sp who="#cassandre-et-villebrequin">
+<sp who="#cassandre #villebrequin">
                         <speaker>CASSANDRE et VILLEBREQUIN, en même temps.</speaker>
                         <p n="6">
 	<s n="1">Vous ? </s>
@@ -982,7 +979,7 @@
 	<s n="1">Quel bruit est-ce que j'entends donc là ?</s>
 </p>
                     </sp>
-<sp who="#cassandre-et-villebrequin">
+<sp who="#cassandre #villebrequin">
                         <speaker>CASSANDRE et VILLEBREQUIN, en même temps.</speaker>
                         <p n="2">
 	<s n="1">Ce n'est pas moi, c'est ce vieux fou... </s>

--- a/tei/gueullette-parade-1.xml
+++ b/tei/gueullette-parade-1.xml
@@ -63,20 +63,17 @@
                     <person xml:id="gillette" sex="FEMALE">
                         <persName>Gillette</persName>
                     </person>
-                    <person xml:id="le-suisse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Suisse</persName>
+                    <person xml:id="le-suisse" sex="MALE">
+                        <persName>Un Suisse</persName>
                     </person>
-                    <person xml:id="olibrius" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Olibrius</persName>
+                    <person xml:id="olibrius" sex="MALE">
+                        <persName>Monsieur Olibrius</persName>
                     </person>
                     <person xml:id="sans-quartier" sex="MALE">
                         <persName>Sans-Quartier</persName>
                     </person>
                     <person xml:id="divertissant" sex="MALE">
                         <persName>Divertissant</persName>
-                    </person>
-                    <person xml:id="sans-quartier-et-divertissant" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Sans Quartier et Divertissant</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -137,13 +134,13 @@
    	<castItem>
                     <role corresp="#gillette">GILLETTE</role>, femme de Gilles.</castItem>
    	<castItem>
-                    <role corresp="#monsieur-olibrius">MONSIEUR OLIBRIUS</role>.</castItem>
+                    <role corresp="#olibrius">MONSIEUR OLIBRIUS</role>.</castItem>
    	<castItem>
                     <role corresp="#sans-quartier">SANS-QUARTIER</role>, valet.</castItem>
    	<castItem>
                     <role corresp="#divertissant">DIVERTISSANT</role>, valet.</castItem>
    	<castItem>
-                    <role corresp="#un-suisse">UN SUISSE</role>.</castItem>
+                    <role corresp="#le-suisse">UN SUISSE</role>.</castItem>
 	</castList>
 	<!--TODO: usage of set in correct place but with unknown attributes <set location="Paris" country="France" periode="XVIIIème" gps="48.856614, 2.352222">.</set>-->
 </front>
@@ -3354,7 +3351,7 @@
 	<s n="4">Et quelle autorité avez-vous donc sur Jacqueline ?</s>
 </p>
                     </sp>
-<sp who="#sans-quartier-et-divertissant">
+<sp who="#sans-quartier #divertissant">
                         <speaker>SANS-QUARTIER et DIVERTISSANT, ensemble.</speaker>
                         <p n="30">
 	<s n="1">C'est ma femme, Monsieur.</s>

--- a/tei/guibert-filles-a-marier.xml
+++ b/tei/guibert-filles-a-marier.xml
@@ -41,17 +41,14 @@
         <profileDesc>
             <particDesc>
                 <listPerson>
-                    <person xml:id="cathis_lolotte" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Cathis_lolotte</persName>
-                    </person>
-                    <person xml:id="broton" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Broton</persName>
+                    <person xml:id="cathis" sex="FEMALE">
+                        <persName>Cathis</persName>
                     </person>
                     <person xml:id="lolotte" sex="FEMALE">
                         <persName>Lolotte</persName>
                     </person>
-                    <person xml:id="cathis" sex="FEMALE">
-                        <persName>Cathis</persName>
+                    <person xml:id="broton" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Broton</persName>
                     </person>
                     <person xml:id="victoire" sex="FEMALE">
                         <persName>Victoire</persName>
@@ -147,7 +144,7 @@ un Manuscrit qui a pour titre : les Filles à Marier, Comédie, et je crois que 
                 <head/>
 <div type="scene" n="1">
                     <head>SCÈNE PREMIÈRE. Monsieur Broton, Cathis, Victoire, Lolotte.</head>
-<sp who="#cathis_lolotte">
+<sp who="#cathis #lolotte">
                         <speaker>CATHIS, ET LOLOTTE, en ensemble suivant.</speaker>
                         <l n="1" part="I">Mon Papa !</l>
                     </sp>
@@ -1249,7 +1246,7 @@ un Manuscrit qui a pour titre : les Filles à Marier, Comédie, et je crois que 
                         <l n="336">Eh bien ! Soyez d'accord, et sans tant de colère,</l>
                         <l n="337">Laisses-lui le mari qui fait votre débat.</l>
                     </sp>
-<sp who="#cathis_lolotte">
+<sp who="#cathis #lolotte">
                         <speaker>LOLOTTE ET CATHIS ensemble.</speaker>
                         <l n="338">Nous n'avons point de goût du tout au célibat ;</l>
                         <l n="339" part="I">Bien des grâces, mon père.</l>
@@ -1258,7 +1255,7 @@ un Manuscrit qui a pour titre : les Filles à Marier, Comédie, et je crois que 
                         <speaker>VICTOIRE.</speaker>
                         <l n="339" part="F">On trouve par la suite.</l>
                     </sp>
-<sp who="#cathis_lolotte">
+<sp who="#cathis #lolotte">
                         <speaker>LOLOTTE ET CATHIS.</speaker>
                         <l n="340" part="I">Milles grâces, ma soeur.</l>
                     </sp>

--- a/tei/harny-petit-maitre-province.xml
+++ b/tei/harny-petit-maitre-province.xml
@@ -69,9 +69,6 @@
                     <person xml:id="la-baronne" sex="FEMALE">
                         <persName>La Baronne</persName>
                     </person>
-                    <person xml:id="le-baron-et-la-baronne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Baron et la Baronne</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -1162,7 +1159,7 @@
                         <speaker>LA BARONNE.</speaker>
                         <l n="422">Monsieur_le_Baron.</l>
                     </sp>
-<sp who="#le-baron-et-la-baronne">
+<sp who="#le-baron #la-baronne">
                         <speaker>LE BARON ET LA BARONNE.</speaker>
                         <l n="423">Prenez-le sur un autre ton.</l>
                     </sp>
@@ -1176,7 +1173,7 @@
                         <l n="426">Je vous ordonne</l>
                         <l n="427">D'épouser le Marquis ce soir.</l>
                     </sp>
-<sp who="#le-baron-et-la-baronne">
+<sp who="#le-baron #la-baronne">
                         <speaker>LE BARON ET LA BARONNE.</speaker>
                         <l n="428">C'est ce qu'il faudra voir,</l>
                     </sp>
@@ -1184,7 +1181,7 @@
                         <speaker>JULIE.</speaker>
                         <l n="429">Ah ! Mon père !</l>
                     </sp>
-<sp who="#le-baron-et-la-baronne">
+<sp who="#le-baron #la-baronne">
                         <speaker>LE BARON ET LA BARONNE.</speaker>
                         <l n="430">Ne me mettez point en colère,</l>
                         <l n="431">Je vous en ferais repentir.</l>
@@ -1193,7 +1190,7 @@
                         <speaker>JULIE.</speaker>
                         <l n="432">Ah ! Ma mère !</l>
                     </sp>
-<sp who="#le-baron-et-la-baronne">
+<sp who="#le-baron #la-baronne">
                         <speaker>LE BARON ET LA BARONNE.</speaker>
                         <l n="433">C'est à  moi qu'il faut obéir. </l>
                     </sp>

--- a/tei/hervilly-malade-reel.xml
+++ b/tei/hervilly-malade-reel.xml
@@ -66,8 +66,11 @@
                     <person xml:id="le-medecin-de-nos-jours" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Medecin de nos Jours</persName>
                     </person>
-                    <person xml:id="les-medecins-et-les-apothicaires" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Les Medecins et les Apothicaires</persName>
+                    <person xml:id="les-medecins" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Medecins</persName>
+                    </person>
+                    <person xml:id="les-apothicaires" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Apothicaires</persName>
                     </person>
                     <person xml:id="tous-les-medecins" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous les Medecins</persName>
@@ -747,7 +750,7 @@
                         <l n="256" part="F">À la bonne heure ! Un remède rapide ! </l>
                         <l n="257" part="I">Sauvez-le ! </l>
                     </sp>
-<sp who="#les-medecins-et-les-apothicaires">
+<sp who="#les-medecins #les-apothicaires">
                         <speaker>LES MÉDÉCINS ET LES APOTHICAIRES.</speaker>
                         <note type="C">Juro : Je le jure (latin)</note>
                         <l n="257" part="M">Juro ! </l>

--- a/tei/hoffman-phedre.xml
+++ b/tei/hoffman-phedre.xml
@@ -77,17 +77,14 @@
                     <person xml:id="un-coriphee" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Coriphee</persName>
                     </person>
-                    <person xml:id="le-peuple_les-grands" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Peuple_les Grands</persName>
-                    </person>
-                    <person xml:id="un-coriphee_choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Un Coriphee_choeurs</persName>
-                    </person>
                     <person xml:id="le-peuple" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Peuple</persName>
                     </person>
-                    <person xml:id="phedre_hippolite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Phedre_hippolite</persName>
+                    <person xml:id="les-grands" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Grands</persName>
+                    </person>
+                    <person xml:id="choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Choeurs</persName>
                     </person>
                     <person xml:id="choeur-de-guerriers" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur de Guerriers</persName>
@@ -719,12 +716,12 @@
                         <l n="264">Grands Dieux ! dans quels moments</l>
                         <l n="265">Me laissez-vous le soin de mon empire ?</l>
                     </sp>
-<sp who="#le-peuple_les-grands">
+<sp who="#le-peuple #les-grands">
                         <speaker>LE PEUPLE et LES GRANDS.</speaker>
                         <l n="266">Dans le malheur qui menace l'empire,</l>
                         <l n="267">Rassurez-nous, Dieux justes, Dieux puissants !</l>
                     </sp>
-<sp who="#un-coriphee_choeurs">
+<sp who="#un-coriphee #choeurs">
                         <speaker>LE CORIPHÉE, les Grands de l'État, et Choeurs de femmes, à Phèdre.</speaker>
                         <l n="268">En vous seule Trézène espère,</l>
                         <l n="269">Trézène obéit à vos lois ;</l>
@@ -1126,7 +1123,7 @@
                         <speaker>OENONE.</speaker>
                         <l n="465">Ô coup inattendu ! Thésée est dans ces lieux.</l>
                     </sp>
-<sp who="#phedre_hippolite">
+<sp who="#phedre #hippolite">
                         <speaker>PHÈDRE et HIPPOLITE.</speaker>
                         <l n="466" part="I">Thésée !</l>
                     </sp>

--- a/tei/hugues-boite-a-musique.xml
+++ b/tei/hugues-boite-a-musique.xml
@@ -59,9 +59,6 @@
                     <person xml:id="le-garde-champetre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Garde Champetre</persName>
                     </person>
-                    <person xml:id="noemie-et-noellie" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Noemie et Noellie</persName>
-                    </person>
                     <person xml:id="la-comtesse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>La Comtesse</persName>
                     </person>
@@ -888,7 +885,7 @@
                         <speaker>LE GARDE CHAMPÊTRE.</speaker>
                         <l n="290" part="I">Je suis garde champêtre.</l>
                     </sp>
-<sp who="#noemie-et-noellie">
+<sp who="#noemie #noellie">
                         <speaker>NOÉMIE et NOELLIE, entraînant le comte.</speaker>
                         <l n="290" part="F">Eh bien ! Passez demain !</l>
                     </sp>

--- a/tei/hugues-tyl.xml
+++ b/tei/hugues-tyl.xml
@@ -77,20 +77,41 @@
                     <person xml:id="les-docteurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Docteurs</persName>
                     </person>
-                    <person xml:id="numer-docteur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numer Docteur</persName>
+                    <person xml:id="docteur-1er" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 1er</persName>
                     </person>
-                    <person xml:id="nume-docteur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Nume Docteur</persName>
+                    <person xml:id="docteur-2e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 2e</persName>
                     </person>
-                    <person xml:id="num0e-docteur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Num0e Docteur</persName>
+                    <person xml:id="docteur-3e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 3e</persName>
                     </person>
-                    <person xml:id="num1e-docteur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Num1e Docteur</persName>
+                    <person xml:id="docteur-4e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 4e</persName>
                     </person>
-                    <person xml:id="num2e-docteur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Num2e Docteur</persName>
+                    <person xml:id="docteur-5e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 5e</persName>
+                    </person>
+                    <person xml:id="docteur-6e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 6e</persName>
+                    </person>
+                    <person xml:id="docteur-7e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 7e</persName>
+                    </person>
+                    <person xml:id="docteur-8e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 8e</persName>
+                    </person>
+                    <person xml:id="docteur-9e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 9e</persName>
+                    </person>
+                    <person xml:id="docteur-10e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 10e</persName>
+                    </person>
+                    <person xml:id="docteur-11e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 11e</persName>
+                    </person>
+                    <person xml:id="docteur-12e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Docteur 12e</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -1479,60 +1500,60 @@
                         <speaker>LE COMTE.</speaker>
                         <l n="433">Soyez les bienvenus, savants hommes de Flandre !</l>
                     </sp>
-<sp who="#numer-docteur">
+<sp who="#docteur-1er">
                         <speaker>1er DOCTEUR.</speaker>
                         <note type="C">Alexandre le Grand, conquérant grec du IVème siècle avec JC. Ici métaphore du conquérant invincible.</note>
                         <l n="434">Vous êtes, Monseigneur, un moderne Alexandre :</l>
                         <l n="435">Vous servez Apollon et Bellone à la fois.</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-2e">
                         <speaker>2e DOCTEUR.</speaker>
                         <l n="436">Le vieil aveugle Homère eût chanté vos exploits.</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-3e">
                         <speaker>3e DOCTEUR.</speaker>
                         <l n="437" part="I">Amo Deum.</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-4e">
                         <speaker>4e DOCTEUR.</speaker>
                         <l n="437" part="M">Rosa, la rose.</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-5e">
                         <speaker>5e DOCTEUR.</speaker>
                         <l n="437" part="F">La syntaxe</l>
                         <l n="438" part="I">Embellit la pensée et la phrase.</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-6e">
                         <speaker>6e DOCTEUR.</speaker>
                         <l n="438" part="F">Elle est l'axe,</l>
                         <l n="439" part="I">L'âme, le contrepoids du discours.</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-7e">
                         <speaker>7e DOCTEUR.</speaker>
                         <l n="439" part="F">Le phénix</l>
                         <l n="440" part="I">Est l'oiseau qui renaît de ses cendrés.</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-8e">
                         <speaker>8e DOCTEUR.</speaker>
                         <l n="440" part="F">Félix</l>
                         <l n="441" part="I">Qui potuit rerum...</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-9e">
                         <speaker>9e DOCTEUR.</speaker>
                         <note type="L">Catachrèse : Trope par lequel un mot détourné de son sens propre est accepté dans le langage commun pour signifier une autre chose qui a quelque analogie avec l'objet qu'il exprimait d'abord ; par exemple, une langue, parce que la langue est le principal organe de la parole articulée ; une glace, grand miroir, parce qu'elle est plane et luisante comme la glace d'un bassin ; une feuille de papier, parce qu'elle est plate et mince comme une feuille d'arbre. [L]</note>
                         <l n="441" part="F">Vive la catachrèse !</l>
                     </sp>
-<sp who="#num0e-docteur">
+<sp who="#docteur-10e">
                         <speaker>10e DOCTEUR.</speaker>
                         <note type="L">Litote : Figure de rhétorique consistant à se servir d'une expression qui dit moins pour faire entendre plus. [L]</note>
                         <l n="442" part="I">La litote a du bon</l>
                     </sp>
-<sp who="#num1e-docteur">
+<sp who="#docteur-11e">
                         <speaker>11e DOCTEUR.</speaker>
                         <l n="442" part="F">J'ai soutenu la thèse</l>
                         <l n="443" part="I">Du libre arbitre.</l>
                     </sp>
-<sp who="#num2e-docteur">
+<sp who="#docteur-12e">
                         <speaker>12e DOCTEUR.</speaker>
                         <l n="443" part="F">L'air est peuplé d'animaux.</l>
                     </sp>
@@ -1598,11 +1619,11 @@
                         <speaker>LE COMTE.</speaker>
                         <l n="462">Après ? Je m'en souviens. J'aime les plantes rares.</l>
                     </sp>
-<sp who="#numer-docteur">
+<sp who="#docteur-1er">
                         <speaker>1er DOCTEUR.</speaker>
                         <l n="463" part="I">Flos, floris.</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-2e">
                         <speaker>2e DOCTEUR.</speaker>
                         <l n="463" part="F">C'est un goût qui vous fait grand honneur.</l>
                     </sp>
@@ -1625,7 +1646,7 @@
                         <l n="469">Vous allez donc me rendre à la douce patrie ?</l>
                         <l n="470">L'exilé souffre, hélas ! Et dans sa rêverie...</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-3e">
                         <speaker>3e DOCTEUR.</speaker>
                         <l n="471" part="I">Nos patrise fines...</l>
                     </sp>
@@ -1640,7 +1661,7 @@
                         <speaker>TYL.</speaker>
                         <l n="475" part="I">J'accepte.</l>
                     </sp>
-<sp who="#numer-docteur">
+<sp who="#docteur-1er">
                         <speaker>1er DOCTEUR.</speaker>
                         <l n="475" part="F">Je commence. Combien de tonneaux faudrait-il</l>
                         <l n="476" part="I">Pour contenir la mer ?</l>
@@ -1666,7 +1687,7 @@
                         <speaker>UN HOMME D'ARMES.</speaker>
                         <l n="482" part="M">Quel gaillard !</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-2e">
                         <speaker>2e DOCTEUR, à part.</speaker>
                         <l n="482" part="F">J'imagine</l>
                         <l n="483">Qu'il répondra moins bien à cette question...</l>
@@ -1678,7 +1699,7 @@
                         <speaker>TYL.</speaker>
                         <l n="485" part="F">Oh ! Bien peu : sept à peine.</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-2e">
                         <speaker>2e DOCTEUR.</speaker>
                         <l n="486" part="I">Sept ! Vous raillez, garçon.</l>
                     </sp>
@@ -1691,7 +1712,7 @@
                         <speaker>ANNA.</speaker>
                         <l n="487" part="F">Comme il vous dit cela !</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-4e">
                         <speaker>4e DOCTEUR.</speaker>
                         <l n="488" part="I">Où donc est le milieu de la terre ?</l>
                     </sp>
@@ -1707,7 +1728,7 @@
                         <l n="493">Une montagne, un ciel d'automne, une rocaille !</l>
                         <l n="494">Sur cette toile-là j'ai peint une bataille !</l>
                     </sp>
-<sp who="#nume-docteur">
+<sp who="#docteur-5e">
                         <speaker>5e DOCTEUR.</speaker>
                         <l n="495">Mais nous ne voyons rien que des murs et des murs !</l>
                     </sp>

--- a/tei/jarry-ubu-roi.xml
+++ b/tei/jarry-ubu-roi.xml
@@ -132,6 +132,9 @@
                     <person xml:id="troisieme-magistrat" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Troisieme Magistrat</persName>
                     </person>
+                    <person xml:id="quatrieme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Quatrieme</persName>
+                    </person>
                     <person xml:id="financiers" sex="MALE">
                         <persName>Financiers</persName>
                     </person>
@@ -173,9 +176,6 @@
                     </person>
                     <person xml:id="troisieme-conseiller" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Troisieme Conseiller</persName>
-                    </person>
-                    <person xml:id="quatrieme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Quatrieme</persName>
                     </person>
                     <person xml:id="soldats-et-palotins" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Soldats et Palotins</persName>

--- a/tei/jarry-ubu-roi.xml
+++ b/tei/jarry-ubu-roi.xml
@@ -177,8 +177,8 @@
                     <person xml:id="troisieme-conseiller" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Troisieme Conseiller</persName>
                     </person>
-                    <person xml:id="soldats-et-palotins" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Soldats et Palotins</persName>
+                    <person xml:id="palotins" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Palotins</persName>
                     </person>
                     <person xml:id="premier-garde" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Premier Garde</persName>
@@ -210,9 +210,6 @@
                     <person xml:id="officiers" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Officiers</persName>
                     </person>
-                    <person xml:id="palotins" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Palotins</persName>
-                    </person>
                     <person xml:id="un-capitaine" sex="MALE">
                         <persName>Un Capitaine</persName>
                     </person>
@@ -242,9 +239,6 @@
                     </person>
                     <person xml:id="un-echo" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Echo</persName>
-                    </person>
-                    <person xml:id="pile-et-cotice" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Pile et Cotice</persName>
                     </person>
                     <person xml:id="voix-au-dehors" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Voix au Dehors</persName>
@@ -3187,7 +3181,7 @@ Ladislas, Père Ubu, Capitaine Bordure et ses Hommes, Giron, Pile, Cotice.</head
 <div type="scene" n="8">
                     <head>SCÈNE VIII.</head>
 <stage type="decor">Le camp sous Varsovie.</stage>
-<sp who="#soldats-et-palotins">
+<sp who="#soldats #palotins">
                         <speaker>SOLDATS ET PALOTINS.</speaker>
                         <p n="1">
 	<s n="1">Vive la Pologne ! </s>
@@ -4212,7 +4206,7 @@ Ladislas, Père Ubu, Capitaine Bordure et ses Hommes, Giron, Pile, Cotice.</head
 </p>
                         <stage type="explosion">Une explosion retentit et l'Ours tombe mort.</stage>
                     </sp>
-<sp who="#pile-et-cotice">
+<sp who="#pile #cotice">
                         <speaker>PILE et COTICE.</speaker>
                         <p n="20">
 	<s n="1">Victoire !</s>

--- a/tei/la-fontaine-astree.xml
+++ b/tei/la-fontaine-astree.xml
@@ -54,9 +54,6 @@
                     <person xml:id="choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur</persName>
                     </person>
-                    <person xml:id="nymphe_acanthe" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Nymphe_acanthe</persName>
-                    </person>
                     <person xml:id="semire" sex="FEMALE">
                         <persName>Sémire</persName>
                     </person>
@@ -69,20 +66,11 @@
                     <person xml:id="hylas" sex="MALE">
                         <persName>Hylas</persName>
                     </person>
-                    <person xml:id="astree_philis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Astree_philis</persName>
-                    </person>
                     <person xml:id="celadon" sex="MALE">
                         <persName>Céladon</persName>
                     </person>
                     <person xml:id="druide" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Druide</persName>
-                    </person>
-                    <person xml:id="druide_choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Druide_choeur</persName>
-                    </person>
-                    <person xml:id="berger_choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Berger_choeur</persName>
                     </person>
                     <person xml:id="berger" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Berger</persName>
@@ -298,7 +286,7 @@
                         <l n="53">Est-il quelques rivages</l>
                         <l n="54">Qui ne connaissent point l'Amour ?</l>
                     </sp>
-<sp who="#nymphe_acanthe">
+<sp who="#nymphe #acanthe">
                         <speaker>LA NYMPHE et ACANTE.</speaker>
                         <l n="55">Si les bergers lui font leur cour,</l>
                         <l n="56">Les rois lui rendent leurs hommages.</l>
@@ -308,7 +296,7 @@
                         <l n="57">Est-il quelques rivages</l>
                         <l n="58">Qui ne connaissent point l'Amour ?</l>
                     </sp>
-<sp who="#nymphe_acanthe">
+<sp who="#nymphe #acanthe">
                         <speaker>LA NYMPHE et ACANTE.</speaker>
                         <l n="59">Il n'est point de lieux si sauvages,</l>
                         <l n="60">De coeurs si fiers, d'esprits si sages,</l>
@@ -569,7 +557,7 @@
                         <speaker>HYLAS.</speaker>
                         <l n="207" part="F">Je vole où votre ordre m'appelle.</l>
                     </sp>
-<sp who="#astree_philis">
+<sp who="#astree #philis">
                         <speaker>ASTRÉE et PHILIS.</speaker>
                         <l n="208">Voyons comment le traître, l'infidèle,</l>
                         <l n="209">Soutiendra son manque de foi.</l>
@@ -708,14 +696,14 @@
                         <l n="282">Ne font régner que de chastes désirs,</l>
                         <l n="283">Et d'innocents plaisirs.</l>
                     </sp>
-<sp who="#druide_choeur">
+<sp who="#druide #choeur">
                         <speaker>LE DRUIDE ET LE CHOEUR.</speaker>
                         <l n="284">Conservez nos troupeaux, arrosez nos prairies ;</l>
                         <l n="285">Faites régner la paix sur ces rives fleuries :</l>
                         <l n="286">Que Mars n'y trouble point les jeux et les chansons ;</l>
                         <l n="287">Gardez nos fruits et nos moissons.</l>
                     </sp>
-<sp who="#berger_choeur">
+<sp who="#berger #choeur">
                         <speaker>UN BERGER ET LE CHOEUR.</speaker>
                         <l n="288">Accourez, bergers fidèles,</l>
                         <l n="289">Célébrez tous, en ce jour,</l>

--- a/tei/la-fontaine-daphne.xml
+++ b/tei/la-fontaine-daphne.xml
@@ -135,9 +135,6 @@
                     <person xml:id="leucippe" sex="MALE">
                         <persName>Leucippe</persName>
                     </person>
-                    <person xml:id="daphne-et-leucippe" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Daphne et Leucippe</persName>
-                    </person>
                     <person xml:id="bacchus" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Bacchus</persName>
                     </person>
@@ -153,17 +150,8 @@
                     <person xml:id="tous-ensemble" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous Ensemble</persName>
                     </person>
-                    <person xml:id="clymene_aminte" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Clymene_aminte</persName>
-                    </person>
                     <person xml:id="ismele" sex="FEMALE">
                         <persName>Ismèle</persName>
-                    </person>
-                    <person xml:id="penee-et-daphne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Penee et Daphne</persName>
-                    </person>
-                    <person xml:id="daphne-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Daphne</persName>
                     </person>
                     <person xml:id="heures" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Heures</persName>
@@ -182,9 +170,6 @@
                     </person>
                     <person xml:id="daphnis" sex="MALE">
                         <persName>Daphnis</persName>
-                    </person>
-                    <person xml:id="philis-et-daphnis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Philis et Daphnis</persName>
                     </person>
                     <person xml:id="un-poete-satirique" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Poete Satirique</persName>
@@ -1431,7 +1416,7 @@
                         <l n="524">Je ne sais rien, pour m'exprimer,</l>
                         <l n="525">Que le langage du silence.</l>
                     </sp>
-<sp who="#daphne-et-leucippe">
+<sp who="#daphne #leucippe">
                         <speaker>DAPHNÉ et LEUCIPPE ensemble.</speaker>
                         <l n="526">Ô bienheureux soupirs, favorables moments</l>
                         <l n="527">Où l'un et l'autre coeur, plein de doux sentiments,</l>
@@ -1647,7 +1632,7 @@
                         <l n="605">Tu dois aux miennes ce berger</l>
                         <l n="606">Que mes faveurs vont rengager.</l>
                     </sp>
-<sp who="#clymene_aminte">
+<sp who="#clymene #aminte">
                         <speaker>CLYMÈNE et AMINTE Ensemble.</speaker>
                         <l n="607">Une fille a cent adresses</l>
                         <l n="608">Pour rebuter un amant ;</l>
@@ -1741,7 +1726,7 @@
                         <l n="666">Approchez-vous, lisez, et que dans ce vallon</l>
                         <l n="667">Un invisible choeur mon oracle répète.</l>
                     </sp>
-<sp who="#penee-et-daphne">
+<sp who="#penee #daphne">
                         <speaker>PÉNÉE et DAPHNÉ lisant. </speaker>
                         <l n="668">Daphné doit aujourd'hui couronner Apollon.</l>
                     </sp>
@@ -1845,7 +1830,7 @@
                         <l n="712" part="F">Ô cieux ! Injustes cieux !</l>
                         <l n="713" part="I">Est-ce là votre arrêt ?</l>
                     </sp>
-<sp who="#daphne-">
+<sp who="#daphne">
                         <speaker>DAPHNÉ.</speaker>
                         <l n="713" part="F">Cet oracle odieux</l>
                         <l n="714" part="I">Vient de mon père seul.</l>
@@ -1856,7 +1841,7 @@
                         <l n="715">Disposent de mon sort, mais non pas de mon âme :</l>
                         <l n="716" part="I">Moi-même en suis-je maître ?</l>
                     </sp>
-<sp who="#daphne-">
+<sp who="#daphne">
                         <speaker>DAPHNÉ.</speaker>
                         <l n="716" part="M">Il le faut.</l>
                     </sp>
@@ -1867,7 +1852,7 @@
                         <l n="718">Et que l'amour possède avecque peu d'empire</l>
                         <l n="719">Un coeur que la contrainte a si tôt entraîné !</l>
                     </sp>
-<sp who="#daphne-">
+<sp who="#daphne">
                         <speaker>DAPHNÉ.</speaker>
                         <l n="720">Quoi ! Faut-il que mon coeur soit par vous soupçonné ?</l>
                         <l n="721">Cruel ! n'avais-je pas encore assez de peine ?</l>
@@ -1878,7 +1863,7 @@
                         <l n="723">Vous serez à Tharsis ; et moi, par mes soupirs,</l>
                         <l n="724">J'augmenterai ses plaisirs.</l>
                     </sp>
-<sp who="#daphne-">
+<sp who="#daphne">
                         <speaker>DAPHNÉ.</speaker>
                         <l n="725">Plût au Ciel que Tharsis causât seul vos alarmes,</l>
                         <l n="726" part="I">Et qu'un père...</l>
@@ -2179,7 +2164,7 @@
                         <l n="871">Et de quoi parlerait-elle,</l>
                         <l n="872">Que d'amour ?</l>
                     </sp>
-<sp who="#philis-et-daphnis">
+<sp who="#philis #daphnis">
                         <speaker>PHILIS et DAPHNIS ensemble.</speaker>
                         <l n="873">Faisons aussi notre cour</l>
                         <l n="874">Au printemps vêtu de roses ;</l>

--- a/tei/la-motte-carnaval-folie.xml
+++ b/tei/la-motte-carnaval-folie.xml
@@ -56,20 +56,17 @@
         <profileDesc>
             <particDesc>
                 <listPerson>
-                    <person xml:id="jupiter-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                    <person xml:id="jupiter" sex="MALE">
                         <persName>Jupiter</persName>
                     </person>
                     <person xml:id="venus" sex="MALE">
                         <persName>Vénus</persName>
                     </person>
-                    <person xml:id="et-le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Et le Choeur</persName>
+                    <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Le Choeur</persName>
                     </person>
                     <person xml:id="choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur</persName>
-                    </person>
-                    <person xml:id="jupiter" sex="MALE">
-                        <persName>Jupiter</persName>
                     </person>
                     <person xml:id="momus" sex="MALE">
                         <persName>Momus</persName>
@@ -100,9 +97,6 @@
                     </person>
                     <person xml:id="le-chef-des-matelots" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Chef des Matelots</persName>
-                    </person>
-                    <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Choeur</persName>
                     </person>
                     <person xml:id="choeur-des-suivantes-de-la-folie" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Suivantes de la Folie</persName>
@@ -232,7 +226,7 @@
 <stage type="decor">Le Théâtre représente les Cieux, où les Dieux sont en festin.</stage>
 <div type="scene" n="1">
                     <head>SCÈNE I.</head>
-<sp who="#jupiter- #venus #et-le-choeur">
+<sp who="#jupiter #venus #le-choeur">
                         <speaker>JUPITER , VENUS, et LE CHOEUR, en se faisant servir le Nectar.</speaker>
                         <l n="1">Qu'à nos voeux ici tout réponde ;</l>
                         <l n="2">Versez-nous, versez-nous la céleste liqueur.</l>

--- a/tei/la-motte-ines-de-castro.xml
+++ b/tei/la-motte-ines-de-castro.xml
@@ -49,8 +49,8 @@
                     <person xml:id="alphonse" sex="MALE">
                         <persName>Alphonse</persName>
                     </person>
-                    <person xml:id="l_ambassadeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>L_ambassadeur</persName>
+                    <person xml:id="l-ambassadeur" sex="MALE">
+                        <persName>L'Ambassadeur</persName>
                     </person>
                     <person xml:id="la-reine" sex="FEMALE">
                         <persName>La Reine</persName>
@@ -165,7 +165,7 @@
 </div>
 <div type="scene" n="2">
                     <head>SCÈNE II. Alphonse, la reine, Inès, Rodrigue, Henrique, et plusieurs courtisans, l'ambassadeur de Castille, et sa suite.</head>
-<sp who="#l_ambassadeur">
+<sp who="#l-ambassadeur">
                         <speaker>L'AMBASSADEUR.</speaker>
                         <l n="7">La gloire dont l'infant couvre votre famille,</l>
                         <l n="8">Autant qu'au Portugal, est chère à la Castille,</l>

--- a/tei/la-motte-scanderberg.xml
+++ b/tei/la-motte-scanderberg.xml
@@ -74,14 +74,14 @@
                     <person xml:id="roxane" sex="MALE">
                         <persName>Roxane</persName>
                     </person>
-                    <person xml:id="choeur-des-sultanes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Choeur des Sultanes</persName>
+                    <person xml:id="sultanes" sex="UNKNOWN">
+                        <persName>Sultanes</persName>
                     </person>
                     <person xml:id="une-sultane" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Une Sultane</persName>
                     </person>
-                    <person xml:id="choeur-des-bostangis-et-des-sultanes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Choeur des Bostangis et des Sultanes</persName>
+                    <person xml:id="bostangis" sex="MALE">
+                        <persName>Bostangis</persName>
                     </person>
                     <person xml:id="servilie" sex="FEMALE">
                         <persName>Servilie</persName>
@@ -584,7 +584,7 @@
                         <l n="197">Qu'à nos concerts l'Écho s'unisse.</l>
                         <l n="198">Faisons tout retentir du doux bruit de nos chants.</l>
                     </sp>
-<sp who="#choeur-des-sultanes">
+<sp who="#sultanes">
                         <speaker>CHOEUR DES SULTANES.</speaker>
                         <l n="199">Que cette grotte s'embellisse,</l>
                         <l n="200">Que l'onde captive y jaillisse,</l>
@@ -674,7 +674,7 @@
                         <l n="243">Que je crains ses transports jaloux !</l>
                         <l n="244">Cherchons à prévenir un trop juste courroux.</l>
                     </sp>
-<sp who="#choeur-des-bostangis-et-des-sultanes">
+<sp who="#bostangis #sultanes">
                         <speaker>CHOEUR DES BOSTANGIS ET DES SULTANES.</speaker>
                         <l n="245">Qu'il revienne comblé de gloire,</l>
                         <l n="246">L'Amour l'attend dans ce séjour :</l>

--- a/tei/laboullaye-cormon-corneille-rotrou.xml
+++ b/tei/laboullaye-cormon-corneille-rotrou.xml
@@ -44,7 +44,7 @@
                         </licence>
                     </availability>
                     <bibl type="originalSource">
-                        <idno type="URL">http://gallica.bnf.fr/ark:/12148/bpt6k6457985</idno>
+                        <idno type="URL">https://gallica.bnf.fr/ark:/12148/bpt6k6457985x</idno>
                     </bibl>
                 </bibl>
             </sourceDesc>
@@ -60,9 +60,6 @@
                     </person>
                     <person xml:id="colletet" sex="MALE">
                         <persName>Colletet</persName>
-                    </person>
-                    <person xml:id="l-etoile-et-boisrobert" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>L Etoile et Boisrobert</persName>
                     </person>
                     <person xml:id="rotrou" sex="MALE">
                         <persName>Rotrou</persName>
@@ -90,9 +87,6 @@
                     </person>
                     <person xml:id="l-huissier" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>L Huissier</persName>
-                    </person>
-                    <person xml:id="boisrobert-et-colletet" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Boisrobert et Colletet</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -481,7 +475,7 @@
 	<s n="1">Vous êtes contents ?</s>
 </p>
                     </sp>
-<sp who="#l-etoile-et-boisrobert">
+<sp who="#l-etoile #boisrobert">
                         <speaker>L'ÉTOILE et BOISROBERT.</speaker>
                         <p n="20">
 	<s n="1">Enchantés !</s>
@@ -3095,7 +3089,7 @@
 	<s n="1">Monseigneur le Cardinal demande auprès de lui Monsieur Corneille.</s>
 </p>
                     </sp>
-<sp who="#tous">
+<sp who="#lamperriere #boisrobert #l-etoile #colletet #rotrou">
                         <speaker>TOUS.</speaker>
                         <p n="7">
 	<s n="1">Corneille !</s>
@@ -3123,7 +3117,7 @@
 	<s n="1">Je n'aurai jamais la force !...</s>
 </p>
                     </sp>
-<sp who="#boisrobert-et-colletet">
+<sp who="#boisrobert #colletet">
                         <speaker>BOISROBERT et COLLETET, à l'Huissier.</speaker>
                         <p n="12">
 	<s n="1">Et nous ?... </s>

--- a/tei/lafont-lesage-querelle-des-theatres.xml
+++ b/tei/lafont-lesage-querelle-des-theatres.xml
@@ -74,8 +74,8 @@
                     <person xml:id="les-deux-comedies" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Deux Comedies</persName>
                     </person>
-                    <person xml:id="la-foire-et-mezettin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Foire et Mezettin</persName>
+                    <person xml:id="mezettin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Mezettin</persName>
                     </person>
                     <person xml:id="polichinelle" sex="MALE">
                         <persName>Polichinelle</persName>
@@ -708,7 +708,7 @@ fariboles, vos fariboles...</s>
                         <speaker>L'OPÉRA.</speaker>
                         <l n="71">Au Public tâchez de plaire,</l>
                     </sp>
-<sp who="#la-foire-et-mezettin">
+<sp who="#la-foire #mezettin">
                         <speaker>LA FOIRE et MEZETTIN.</speaker>
                         <l n="72">Au Public tâchons de plaire,</l>
                     </sp>
@@ -716,7 +716,7 @@ fariboles, vos fariboles...</s>
                         <speaker>L'OPÉRA.</speaker>
                         <l n="73">Et méprisez leur colère.</l>
                     </sp>
-<sp who="#la-foire-et-mezettin">
+<sp who="#la-foire #mezettin">
                         <speaker>LA FOIRE et MEZETTIN.</speaker>
                         <l n="74">Et méprisons leur colère.</l>
                     </sp>
@@ -724,7 +724,7 @@ fariboles, vos fariboles...</s>
                         <speaker>L'OPÉRA.</speaker>
                         <l n="75">Au Public tâchez de plaire,</l>
                     </sp>
-<sp who="#la-foire-et-mezettin">
+<sp who="#la-foire #mezettin">
                         <speaker>LA FOIRE et MEZETTIN.</speaker>
                         <l n="76">Au Public tâchons de plaire,</l>
                     </sp>
@@ -732,7 +732,7 @@ fariboles, vos fariboles...</s>
                         <speaker>L'OPÉRA.</speaker>
                         <l n="77">Pouvez-vous mieux vous venger.</l>
                     </sp>
-<sp who="#la-foire-et-mezettin">
+<sp who="#la-foire #mezettin">
                         <speaker>LA FOIRE et MEZETTIN.</speaker>
                         <l n="78">Pouvons-nous mieux nous venger.</l>
                     </sp>

--- a/tei/lafont-naufrage.xml
+++ b/tei/lafont-naufrage.xml
@@ -63,17 +63,14 @@
                     <person xml:id="licandre" sex="MALE">
                         <persName>Licandre</persName>
                     </person>
-                    <person xml:id="grand-pretre_grande-pretresse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Grand Pretre_grande Pretresse</persName>
+                    <person xml:id="grand-pretre" sex="MALE">
+                        <persName>Le Grand-Prêtre de l'Ile</persName>
                     </person>
-                    <person xml:id="la-grande-pretresse" sex="FEMALE">
+                    <person xml:id="grande-pretresse" sex="FEMALE">
                         <persName>La Grande-Prêtresse</persName>
                     </person>
                     <person xml:id="choeur-d-insulaires" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur D Insulaires</persName>
-                    </person>
-                    <person xml:id="le-grand-pretre" sex="MALE">
-                        <persName>Le Grand-Prêtre de l'Ile</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -139,9 +136,9 @@
 	<castItem>
                     <role corresp="#un-insulaire">UN INSULAIRE</role>.</castItem> 
 	<castItem>
-                    <role corresp="#le-grand-pretre">LE GRAND-PRÊTRE de l'île</role>.</castItem> 	
+                    <role corresp="#grand-pretre">LE GRAND-PRÊTRE de l'île</role>.</castItem> 	
 	<castItem>
-                    <role corresp="#la-grande-pretresse">LA GRANDE-PRÊTRESSE</role>.</castItem> 	
+                    <role corresp="#grande-pretresse">LA GRANDE-PRÊTRESSE</role>.</castItem> 	
 	<castItem>
                     <role corresp="#gardes">GARDES et suite du gouverneur.</role>.</castItem> 	
 	<castItem>
@@ -1226,15 +1223,15 @@
                         <l n="357">Je dois être brûlé tout vif... Ô sort affreux !...</l>
                         <l n="358">Mon maître, quoique mort, est, ma foi, plus heureux.</l>
                     </sp>
-<sp who="#grand-pretre_grande-pretresse">
-                        <speaker>LEGRAND-PRÊTRE et LA GRANDE-PRÊTRESSE chantant ensemble.</speaker>
+<sp who="#grand-pretre #grande-pretresse">
+                        <speaker>LE GRAND-PRÊTRE et LA GRANDE-PRÊTRESSE chantant ensemble.</speaker>
                         <l n="359">Crispin, il faut braver le sort.</l>
                         <l n="360">Par lui ta femme t'est ravie :</l>
                         <l n="361">Rejoins-la par un noble effort.</l>
                         <l n="362">Pour elle tu brûlais, brûlais, pendant sa vie,</l>
                         <l n="363">Brûle, brûle, avec elle, après sa mort,</l>
                     </sp>
-<sp who="#la-grande-pretresse">
+<sp who="#grande-pretresse">
                         <speaker>LA GRANDE-PRÊTRESSE chantant seule, à Crispin.</speaker>
                         <l n="364">D'un long veuvage on n'a point l'amertume</l>
                         <l n="365">En suivant sa femme au tombeau.</l>
@@ -1256,7 +1253,7 @@
                         <speaker>CHOEUR D'INSULAIRES, de l'un et de l'autre sexes, montrant Crispin.</speaker>
                         <l n="376">Chantons, dansons, et célébrons son sort.</l>
                     </sp>
-<sp who="#la-grande-pretresse">
+<sp who="#grande-pretresse">
                         <speaker>LA GRANDE-PRÊTRESSE, chantant seule, montrant Crispin.</speaker>
                         <l n="377">Dans ses yeux sa joie est bien peinte.</l>
                         <l n="378">Qu'il est content ! Qu'il est heureux !</l>
@@ -1371,7 +1368,7 @@
                         <l n="413" part="F">Oui, Dieu merci !</l>
                         <l n="414" part="I">Le poison a raté.</l>
                     </sp>
-<sp who="#le-grand-pretre">
+<sp who="#grand-pretre">
                         <speaker>LE GRAND-PRÊTRE, au gouverneur, avec sévérité.</speaker>
                         <l n="414" part="F">Que vois-je ici paraître ?</l>
                         <l n="415">Avez-vous prétendu vous moquer du grand-prêtre, </l>
@@ -1385,7 +1382,7 @@
                         <l n="419">M'a fait, blessant vos lois, un peu trop entreprendre. </l>
                         <l n="420" part="I">Il était mon époux.</l>
                     </sp>
-<sp who="#le-grand-pretre">
+<sp who="#grand-pretre">
                         <speaker>LE GRAND-PRÊTRE.</speaker>
                         <l n="420" part="F">Votre époux ? Eh ! Pourquoi </l>
                         <l n="421">Ne me pas confier un tel secret, à moi ?</l>
@@ -1402,7 +1399,7 @@
                         <speaker>LE GOUVERNEUR.</speaker>
                         <l n="429" part="I">Oui, sans doute;</l>
                     </sp>
-<sp who="#le-grand-pretre">
+<sp who="#grand-pretre">
                         <speaker>LE GRAND-PRÊTRE, à Licandre et à Éliante.</speaker>
                         <l n="429" part="M">Ainsi donc, vivez heureux.</l>
                     </sp>
@@ -1472,7 +1469,7 @@
                         <l n="453">Que je ne serai point sujet à votre loi.</l>
                         <stage type="danse">Les insulaires des deux sexes forment des danses.</stage>
                     </sp>
-<sp who="#le-grand-pretre">
+<sp who="#grand-pretre">
                         <speaker>LE GRAND-PRÊTRE, chantant seul, à Licandre, à Éliante et à Crispin.</speaker>
                         <l n="454">Étrangers, qui trouvez ridicule</l>
                         <l n="455">Qu'ici l'on brûle</l>
@@ -1484,7 +1481,7 @@
                         <l n="461">À la mort de son époux.</l>
                         <stage type="danse">Les insulaires, des deux sexes, reprennent leurs danses.</stage>
                     </sp>
-<sp who="#la-grande-pretresse">
+<sp who="#grande-pretresse">
                         <speaker>LA GRANDE-PRÊTRESSE, chantant seule, à Licandre, à Éliante et à Crispin.</speaker>
                         <l n="462">Si vous voulez, malgré l'orage,</l>
                         <l n="463">Voguer encore en ce beau jour,</l>

--- a/tei/laujon-hero-leandre.xml
+++ b/tei/laujon-hero-leandre.xml
@@ -48,9 +48,6 @@
                     <person xml:id="hero" sex="FEMALE">
                         <persName>Héro</persName>
                     </person>
-                    <person xml:id="leandre-et-hero" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Leandre et Hero</persName>
-                    </person>
                     <person xml:id="choeur-de-pretresses-de-venus" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur de Pretresses de Venus</persName>
                     </person>
@@ -169,7 +166,7 @@
                         <speaker>HÉRO.</speaker>
                         <l n="14">Tu sais que divisés, par dés haines cruelles...</l>
                     </sp>
-<sp who="#leandre-et-hero">
+<sp who="#leandre #hero">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="15">Leurs coeurs ne sont d'accord que pour briser nos noeuds ?</l>
                         <l n="16">Tu nous fais oublier nos craintes mutuelles</l>
@@ -183,7 +180,7 @@
                         <speaker>LÉANDRE.</speaker>
                         <l n="18" part="M">Héro !...</l>
                     </sp>
-<sp who="#leandre-et-hero">
+<sp who="#leandre #hero">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="18" part="F">Tous deux sont dignes de te plaire</l>
                         <l n="19">En prolongeant, pour eux ta course tutélaire</l>
@@ -227,7 +224,7 @@
                         <l n="42">Eh! de tous les écueils, le plus cruel pour moi,</l>
                         <l n="43">C'est le port où je vais retrouver mon asile.</l>
                     </sp>
-<sp who="#leandre-et-hero">
+<sp who="#leandre #hero">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="44">Pourquoi vous opposer sans cesse à nos amours,</l>
                         <l n="45">Trop cruels auteurs de nos jours ?</l>
@@ -248,7 +245,7 @@
                         <l n="53">Elle nous apprend par ses pleurs</l>
                         <l n="54">Ce qu'il doit en coûter à quitter ce qu'on aime.</l>
                     </sp>
-<sp who="#leandre-et-hero">
+<sp who="#leandre #hero">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="55">Il faut nous séparer quel moment pour nos coeurs !</l>
                     </sp>
@@ -442,7 +439,7 @@
                         <l n="135">Pour couronner votre constance,</l>
                         <l n="136">L'Amour vous appelle en ces lieux.</l>
                     </sp>
-<sp who="#leandre-et-hero">
+<sp who="#leandre #hero">
                         <speaker>LÉANDRE ET HÉRO.</speaker>
                         <l n="137">Je revois enfin ce que j'aime ;</l>
                         <l n="138">J'en crois à peine et mon coeur et mes yeux.</l>
@@ -466,7 +463,7 @@
                         <speaker>NEPTUNE.</speaker>
                         <l n="150">Formez une chaîne éternelle !</l>
                     </sp>
-<sp who="#leandre-et-hero">
+<sp who="#leandre #hero">
                         <speaker>LÉANDRE ET HÉRO.</speaker>
                         <l n="151">Formons une chaîne éternelle !</l>
                     </sp>

--- a/tei/launay-francais-chez-les-hurons.xml
+++ b/tei/launay-francais-chez-les-hurons.xml
@@ -68,8 +68,8 @@
                     <person xml:id="deuxieme-huron" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Deuxieme Huron</persName>
                     </person>
-                    <person xml:id="nume-huron" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Nume Huron</persName>
+                    <person xml:id="huron-3e" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Huron 3e</persName>
                     </person>
                     <person xml:id="quatuor" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Quatuor</persName>
@@ -1232,7 +1232,7 @@
 	<s n="1">Et vous n'avez fait aucun effort pour sauver votre chef ?</s>
 </p>
                     </sp>
-<sp who="#nume-huron">
+<sp who="#huron-3e">
                         <speaker>3e HURON.</speaker>
                         <p n="10">
 	<s n="1">Que nous sommes malheureux, d'être en trop petit nombres pour oser tenter de l'arracher des mains d'une si grande multitude !</s>

--- a/tei/le-boulanger-chalussay-elomire-hypocondre.xml
+++ b/tei/le-boulanger-chalussay-elomire-hypocondre.xml
@@ -81,9 +81,6 @@
                     <person xml:id="epistenez" sex="MALE">
                         <persName>Epistenez</persName>
                     </person>
-                    <person xml:id="alcandre-et-eraste" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Alcandre et Eraste</persName>
-                    </person>
                     <person xml:id="oronte" sex="MALE">
                         <persName>Oronte</persName>
                     </person>
@@ -1935,7 +1932,7 @@
                         <l n="731">Je ferai bien, sans vous, un si fâcheux voyage ; </l>
                         <l n="732" part="I">N'en savez-vous pas plus ?</l>
                     </sp>
-<sp who="#alcandre-et-eraste">
+<sp who="#alcandre #eraste">
                         <speaker>ALCANDRE et ERASTE, ensemble.</speaker>
                         <l n="732" part="M">Non.</l>
                     </sp>

--- a/tei/lemerciere-le-miracle-rate.xml
+++ b/tei/lemerciere-le-miracle-rate.xml
@@ -44,8 +44,8 @@
         <profileDesc>
             <particDesc>
                 <listPerson>
-                    <person xml:id="empty-string" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Empty String</persName>
+                    <person xml:id="l-enfant" sex="FEMALE">
+                        <persName>L'Enfant</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -95,8 +95,7 @@
                 <head>LE MIRACLE RATÉ</head>
 <div type="scene" n="1">
                     <head/>
-<sp who="#empty-string">
-                        <speaker/>
+<sp who="#l-enfant">
                         <ab type="poem"><!--<poem>-->
 <lg n="1">
 	<l n="1">C'était le curé du hameau,</l>

--- a/tei/lesage-dorneval-ile-gougou.xml
+++ b/tei/lesage-dorneval-ile-gougou.xml
@@ -59,8 +59,8 @@
                     <person xml:id="leandre" sex="MALE">
                         <persName>Léandre</persName>
                     </person>
-                    <person xml:id="choeur-de-sauvages" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Choeur de Sauvages</persName>
+                    <person xml:id="sauvages" sex="UNKNOWN">
+                        <persName>Troupe de Sauvages</persName>
                     </person>
                     <person xml:id="un-sauvage" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Sauvage</persName>
@@ -71,14 +71,8 @@
                     <person xml:id="le-sagamo" sex="MALE">
                         <persName>Le Sagamo</persName>
                     </person>
-                    <person xml:id="les-sauvages" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Les Sauvages</persName>
-                    </person>
                     <person xml:id="pierrot" sex="MALE">
                         <persName>Pierrot</persName>
-                    </person>
-                    <person xml:id="pierrot-et-les-sauvages" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Pierrot et les Sauvages</persName>
                     </person>
                     <person xml:id="premier-sauvage" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Premier Sauvage</persName>
@@ -188,7 +182,7 @@
 			<castItem>
                     <role corresp="#le-favori-du-sagamo">LE FAVORI du SAGAMO</role>.</castItem>
 			<castItem>
-                    <role corresp="#troupe-de-sauvages">TROUPE DE SAUVAGES</role>.</castItem>
+                    <role corresp="#sauvages">TROUPE DE SAUVAGES</role>.</castItem>
 			<castItem>
                     <role corresp="#troupes-de-lutins">TROUPES DE LUTINS</role>.</castItem>
 		</castList>
@@ -290,7 +284,7 @@
 <div type="scene" n="3">
                     <head>SCÈNE III. Léandre, Arlequin, Le Sagamo et suite.</head>
 <stage type="narration">Le Sagamo paraît. Il est précédé par plusieurs sauvages dont les uns portent des arcs et des flèches, les autres des massues ; il y en a qui font résonner des orgues de barbarie et d'autres qui frappent sur des plaques de cuivre. Devant lui est une petite danseuse qui porte son calumet. Quantité de ses officiers le suivent, ayant tous le sabre nu à la main.</stage>
-<sp who="#choeur-de-sauvages">
+<sp who="#sauvages">
                         <speaker>CHOEUR DE SAUVAGES</speaker>
                         <stage type="title">Air du choeur des Bostangis de L'Europe galante, 5e entrée, scène 5.</stage>
                         <l n="1">Vivo vivo</l>
@@ -400,7 +394,7 @@
 </p>
                         <stage type="help/threat">Sitôt qu'Arlequin est déchaîné, il va sauter au cou du Sagamo et le renverse.</stage>
                     </sp>
-<sp who="#les-sauvages">
+<sp who="#sauvages">
                         <speaker>LES SAUVAGES, empoignant Arlequin.</speaker>
                         <p n="17">
 	<s n="1">Tuac, tuac, l'insolentac !</s>
@@ -574,7 +568,7 @@
 </p>
                         <stage type="drink/shout">Il veut boire un verre de vin qu'il tient, mais les sauvages par leurs cris lui font répandre. </stage>
                     </sp>
-<sp who="#pierrot-et-les-sauvages">
+<sp who="#pierrot #sauvages">
                         <speaker>PIERROT et les SAUVAGES se prosternent à terre et poussent de grands cris de joie.</speaker>
                         <p n="7">
 	<s n="1">Haleatibou ! </s>

--- a/tei/marivaux-fausse-suivante.xml
+++ b/tei/marivaux-fausse-suivante.xml
@@ -74,9 +74,6 @@
                     <person xml:id="un-valet" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Valet</persName>
                     </person>
-                    <person xml:id="trivelin_arlequin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Trivelin_arlequin</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -6109,7 +6106,7 @@
 	<s n="5">Tenez, mes enfants, vendez cela, et partagez-en l'argent.!</s>
 </p>
                     </sp>
-<sp who="#trivelin_arlequin">
+<sp who="#trivelin #arlequin">
                         <speaker>TRIVELIN et ARLEQUIN.</speaker>
                         <p n="22">
 	<s n="1">Grand merci !</s>

--- a/tei/marivaux-heritier-de-village.xml
+++ b/tei/marivaux-heritier-de-village.xml
@@ -65,9 +65,6 @@
                     <person xml:id="colette" sex="FEMALE">
                         <persName>Colette</persName>
                     </person>
-                    <person xml:id="claudine_blaise" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Claudine_blaise</persName>
-                    </person>
                     <person xml:id="le-fiscal" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Fiscal</persName>
                     </person>
@@ -1220,7 +1217,7 @@
 	<s n="5">Que de grâces et de gentillesses !</s>
 </p>
                     </sp>
-<sp who="#claudine_blaise">
+<sp who="#claudine #blaise">
                         <speaker>Claudine et Blaise.</speaker>
                         <p n="36">
 	<s n="1">Ah ! </s>

--- a/tei/marivaux-heureux-stratageme.xml
+++ b/tei/marivaux-heureux-stratageme.xml
@@ -71,11 +71,8 @@
                     <person xml:id="le-chevalier" sex="MALE">
                         <persName>Le Chevalier</persName>
                     </person>
-                    <person xml:id="le6laquais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le6laquais</persName>
-                    </person>
-                    <person xml:id="la-marquise_le-chevalier" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Marquise_le Chevalier</persName>
+                    <person xml:id="le-laquais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Le Laquais</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -2637,7 +2634,7 @@
 	<s n="2">Parlerai-je à ta maîtresse ?</s>
 </p>
                     </sp>
-<sp who="#le6laquais">
+<sp who="#le-laquais">
                         <speaker>LE LAQUAIS.</speaker>
                         <p n="11">
 	<s n="1">Oui, Madame, la voilà qui arrive.</s>
@@ -4030,7 +4027,7 @@
 	<s n="">Hi !</s>
 </p>
                     </sp>
-<sp who="#la-marquise_le-chevalier">
+<sp who="#la-marquise #le-chevalier">
                         <speaker>LA MARQUISE et le CHEVALIER rient.</speaker>
                         <p n="">
 	<s n="">Eh ! </s>

--- a/tei/marivaux-triomphe-de-l-amour.xml
+++ b/tei/marivaux-triomphe-de-l-amour.xml
@@ -65,9 +65,6 @@
                     <person xml:id="hermocrate" sex="MALE">
                         <persName>Hermocrate</persName>
                     </person>
-                    <person xml:id="phocion-et-agis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Phocion et Agis</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -2362,7 +2359,7 @@
 	<s n="1">Toujours, Madame, d'autant plus qu'il n'y a rien à craindre ; puisqu'il ne s'agit entre nous que d'amitié, qui est le seul penchant que je puisse inspirer, et le seul aussi, sans doute, dont vous soyez capable.</s>
 </p>
                     </sp>
-<sp who="#phocion-et-agis">
+<sp who="#phocion #agis">
                         <speaker>PHOCION et AGIS, en même temps.</speaker>
                         <p n="38">
 	<s n="1">Ah !</s>

--- a/tei/marmontel-hercule-mourant.xml
+++ b/tei/marmontel-hercule-mourant.xml
@@ -64,14 +64,8 @@
                     <person xml:id="la-jalousie" sex="FEMALE">
                         <persName>La Jalousie</persName>
                     </person>
-                    <person xml:id="junon_la-jalousie" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Junon_la Jalousie</persName>
-                    </person>
                     <person xml:id="iole" sex="FEMALE">
                         <persName>Iole</persName>
-                    </person>
-                    <person xml:id="iole_hilus" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Iole_hilus</persName>
                     </person>
                     <person xml:id="le-choeur-des-captifs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Choeur des Captifs</persName>
@@ -93,12 +87,6 @@
                     </person>
                     <person xml:id="le-thessalien" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Thessalien</persName>
-                    </person>
-                    <person xml:id="le-choeur_dejanire" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Choeur_dejanire</persName>
-                    </person>
-                    <person xml:id="le-grand-pretre_le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Grand Pretre_le Choeur</persName>
                     </person>
                     <person xml:id="le-grand-pretre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Grand Pretre</persName>
@@ -343,7 +331,7 @@
                         <l n="84">Par la voix de Dircé, sa compagne fidèle,</l>
                         <l n="85">Venez percer son coeur des plus sensibles coups.</l>
                     </sp>
-<sp who="#junon_la-jalousie">
+<sp who="#junon #la-jalousie">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="86">Que le désespoir, la fureur,</l>
                         <l n="87">Embrasent, dévorent son âme,</l>
@@ -472,7 +460,7 @@
                         <l n="147">De nous voir et de nous entendre</l>
                         <l n="148">Fuyons, s'il se peut, le danger.</l>
                     </sp>
-<sp who="#iole_hilus">
+<sp who="#iole #hilus">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="149">La plaisir de mêler nos larmes</l>
                         <l n="150">N'adoucira plus nos malheurs.</l>
@@ -972,7 +960,7 @@
                         <l n="380">Attirez sur moi le tonnerre ;</l>
                         <l n="381">Qu'Alcide vive, c'est assez.</l>
                     </sp>
-<sp who="#le-choeur_dejanire">
+<sp who="#le-choeur #dejanire">
                         <speaker>LE CHOEUR avec Déjanire.</speaker>
                         <l n="382">Dieu, grand Dieu ! sois sensible à sa / ma douleur profonde ;</l>
                         <l n="383">Protège un héros cher au monde.</l>
@@ -984,13 +972,13 @@
                         <l n="386">Hélas ! ma main seule est coupable,</l>
                         <l n="387">Et mon coeur, tu le sais, mon coeur est innocent.</l>
                     </sp>
-<sp who="#le-choeur_dejanire">
+<sp who="#le-choeur #dejanire">
                         <speaker>LE CHOEUR avec Déjanire.</speaker>
                         <l n="388">Dieu, grand Dieu ! sois sensible à sa / ma douleur profonde ;</l>
                         <l n="389">Protège un héros cher au monde.</l>
                         <stage type="danse">On danse.</stage>
                     </sp>
-<sp who="#le-grand-pretre_le-choeur">
+<sp who="#le-grand-pretre #le-choeur">
                         <speaker>LE GRAND PRÊTRE et le Choeur.</speaker>
                         <l n="390">Père d'Alcide, à tes genoux,</l>
                         <l n="391">Pour lui nos voeux se font entendre.</l>

--- a/tei/marmontel-huron.xml
+++ b/tei/marmontel-huron.xml
@@ -49,8 +49,8 @@
                     <person xml:id="mlle-de-saint-yves" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Mlle de Saint Yves</persName>
                     </person>
-                    <person xml:id="mlle-de-kerkabon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Mlle de Kerkabon</persName>
+                    <person xml:id="mlle-de-kerkabon" sex="FEMALE">
+                        <persName>Mademoiselle de Kerkabon</persName>
                     </person>
                     <person xml:id="gilotin" sex="MALE">
                         <persName>Gilotin</persName>
@@ -58,11 +58,8 @@
                     <person xml:id="le-huron" sex="MALE">
                         <persName>Le Huron</persName>
                     </person>
-                    <person xml:id="kerkabon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Kerkabon</persName>
-                    </person>
-                    <person xml:id="m-et-mlle-de-kerkabon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>M et Mlle de Kerkabon</persName>
+                    <person xml:id="kerkabon" sex="MALE">
+                        <persName>Monsieur de Kerkabon</persName>
                     </person>
                     <person xml:id="monsieur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Monsieur</persName>
@@ -138,9 +135,9 @@
 			<castItem>
                     <role corresp="#monsieur-de-saint-yves">MONSIEUR DE SAINT-YVES</role>, son père.</castItem>
 			<castItem>
-                    <role corresp="#mademoiselle-de-kerkabon">MADEMOISELLE DE KERKABON</role>.</castItem>
+                    <role corresp="#mlle-de-kerkabon">MADEMOISELLE DE KERKABON</role>.</castItem>
 			<castItem>
-                    <role corresp="#monsieur-de-kerkabon">MONSIEUR DE KERKABON</role>, son frère.</castItem>
+                    <role corresp="#kerkabon">MONSIEUR DE KERKABON</role>, son frère.</castItem>
 			<castItem>
                     <role corresp="#le-bailli">LE BAILLI</role>.</castItem>
 			<castItem>
@@ -926,7 +923,7 @@
                         <speaker>MADEMOISELLE DE KERKABON.</speaker>
                         <l n="296">Il a les yeux de sa mère.</l>
                     </sp>
-<sp who="#m-et-mlle-de-kerkabon">
+<sp who="#kerkabon #mlle-de-kerkabon">
                         <speaker>MONSIEUR et MADEMOISELLE DE KERKABON.</speaker>
                         <l n="297">Voilà ses yeux, voilà ses traits,</l>
                         <l n="298">Ces traits de caractère.</l>
@@ -940,7 +937,7 @@
                         <speaker>MADEMOISELLE DE SAINT-YVES.</speaker>
                         <l n="301">Il est Français.</l>
                     </sp>
-<sp who="#m-et-mlle-de-kerkabon">
+<sp who="#kerkabon #mlle-de-kerkabon">
                         <speaker>MONSIEUR et MADEMOISELLE DE KERKABON.</speaker>
                         <l n="302">Voilà ces traits de caractère.</l>
                     </sp>
@@ -949,7 +946,7 @@
                         <l n="303">N'ai-je pas encor quelques traits</l>
                         <l n="304">De caractère ?</l>
                     </sp>
-<sp who="#m-et-mlle-de-kerkabon">
+<sp who="#kerkabon #mlle-de-kerkabon">
                         <speaker>MONSIEUR et MADEMOISELLE DE KERKABON.</speaker>
                         <l n="305">Voilà tes yeux, voilà tes traits.</l>
                     </sp>

--- a/tei/maupassant-a-la-feuille-de-rose.xml
+++ b/tei/maupassant-a-la-feuille-de-rose.xml
@@ -76,23 +76,23 @@
                     <person xml:id="fatma" sex="MALE">
                         <persName>Fatma</persName>
                     </person>
-                    <person xml:id="le-capitaine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Capitaine</persName>
+                    <person xml:id="le-capitaine" sex="MALE">
+                        <persName>Un Capitaine Retraité</persName>
                     </person>
                     <person xml:id="blondinette" sex="MALE">
                         <persName>Blondinette</persName>
                     </person>
-                    <person xml:id="le-marseillais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Marseillais</persName>
+                    <person xml:id="le-marseillais" sex="MALE">
+                        <persName>Un Marseillais</persName>
                     </person>
-                    <person xml:id="le-jeune-homme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Jeune Homme</persName>
+                    <person xml:id="le-jeune-homme" sex="MALE">
+                        <persName>Un Jeune Homme</persName>
                     </person>
-                    <person xml:id="le-sapeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Sapeur</persName>
+                    <person xml:id="le-sapeur" sex="MALE">
+                        <persName>Un Sapeur</persName>
                     </person>
-                    <person xml:id="l-anglais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>L Anglais</persName>
+                    <person xml:id="l-anglais" sex="MALE">
+                        <persName>Un Anglais</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -153,15 +153,15 @@
 		<castItem>
                     <role corresp="#blondinette">BLONDINETTE</role>, Employée du bordel.</castItem>
 		<castItem>
-                    <role corresp="#empty-string">UN CAPITAINE RETRAITÉ</role>.</castItem>
+                    <role corresp="#le-capitaine">UN CAPITAINE RETRAITÉ</role>.</castItem>
 		<castItem>
-                    <role corresp="#empty-string">UN JEUNE HOMME</role>.</castItem>
+                    <role corresp="#le-jeune-homme">UN JEUNE HOMME</role>.</castItem>
 		<castItem>
-                    <role corresp="#un-sapeur">UN SAPEUR</role>.</castItem>
+                    <role corresp="#le-sapeur">UN SAPEUR</role>.</castItem>
 		<castItem>
-                    <role corresp="#un-marseillais">UN MARSEILLAIS</role>.</castItem>
+                    <role corresp="#le-marseillais">UN MARSEILLAIS</role>.</castItem>
 		<castItem>
-                    <role corresp="#un-anglais">UN ANGLAIS</role>.</castItem>
+                    <role corresp="#l-anglais">UN ANGLAIS</role>.</castItem>
 	</castList>
 <!--TODO: usage of set in correct place but with unknown attributes <set location="Paris" country="France" periode="XIXème" gps="">La scène se passe à Paris de nos jours dans un salon de bordel.</set>-->
 </front>

--- a/tei/mercier-destruction-de-la-ligue.xml
+++ b/tei/mercier-destruction-de-la-ligue.xml
@@ -134,9 +134,6 @@
                     <person xml:id="le-jeune-suisse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Jeune Suisse</persName>
                     </person>
-                    <person xml:id="hilaire-pere_hilaire-fils" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Hilaire Pere_hilaire Fils</persName>
-                    </person>
                     <person xml:id="un-ligueur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Ligueur</persName>
                     </person>
@@ -4066,7 +4063,7 @@
 	<s n="14">Où êtes-vous tous ?</s>
 </p>
                     </sp>
-<sp who="#hilaire-pere_hilaire-fils">
+<sp who="#hilaire-pere #hilaire-fils">
                         <speaker>HILAIRE père et fils.</speaker>
                         <p n="72">
 	<s n="1">Nous sommes dans vos bras.</s>

--- a/tei/merle-a-bas-moliere.xml
+++ b/tei/merle-a-bas-moliere.xml
@@ -59,9 +59,6 @@
                     <person xml:id="dandinville" sex="MALE">
                         <persName>Dandinville</persName>
                     </person>
-                    <person xml:id="malingre-et-dandinville" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Malingre et Dandinville</persName>
-                    </person>
                     <person xml:id="tous" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous</persName>
                     </person>
@@ -374,7 +371,7 @@
 	<s n="1">J'y serai.</s>
 </p>
                     </sp>
-<sp who="#malingre-et-dandinville">
+<sp who="#malingre #dandinville">
                         <speaker>MALINGRE et DANDINVILLE.</speaker>
                         <p n="32">
 	<s n="">Nous y serons tous en dépit de Molière.</s>

--- a/tei/mirbeau-epidemie.xml
+++ b/tei/mirbeau-epidemie.xml
@@ -73,9 +73,6 @@
                     <person xml:id="le-membre-de-la-majorite" sex="MALE">
                         <persName>Le Membre de la Majorité</persName>
                     </person>
-                    <person xml:id="membres-de-l-opposition-et-de-la-majorite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Membres de L Opposition et de la Majorite</persName>
-                    </person>
                     <person xml:id="tous" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous</persName>
                     </person>
@@ -779,7 +776,7 @@ de la pièce.</stage>
 	<s n="1">Vous voyez bien, Messieurs, qu'il ne s'agit pas de politique !</s>
 </p>
                     </sp>
-<sp who="#membres-de-l-opposition-et-de-la-majorite">
+<sp who="#le-membre-de-l-opposition #le-membre-de-la-majorite">
                         <speaker>LES MEMBRES DE L'OPPOSITION ET DE LA MAJORITÉ, ensemble.</speaker>
                         <p n="87">
 	<s n="1">Sur la ville !... </s>

--- a/tei/moinaux-la-fiacre-cuisine.xml
+++ b/tei/moinaux-la-fiacre-cuisine.xml
@@ -46,7 +46,7 @@
                     <person xml:id="le-narrateur" sex="MALE">
                         <persName>Le Narrateur</persName>
                     </person>
-                    <person xml:id="le-cocher-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                    <person xml:id="le-cocher" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Cocher</persName>
                     </person>
                     <person xml:id="monsieur-le-president" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
@@ -54,9 +54,6 @@
                     </person>
                     <person xml:id="le-prevenu" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Prevenu</persName>
-                    </person>
-                    <person xml:id="le-cocher" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Cocher</persName>
                     </person>
                 </listPerson>
             </particDesc>

--- a/tei/moissy-liaisons-dangereuses.xml
+++ b/tei/moissy-liaisons-dangereuses.xml
@@ -56,11 +56,11 @@
                     <person xml:id="dubois" sex="MALE">
                         <persName>Dubois</persName>
                     </person>
-                    <person xml:id="contois" sex="MALE">
-                        <persName>Contois</persName>
-                    </person>
                     <person xml:id="monsieur-farnoze" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Monsieur Farnoze</persName>
+                    </person>
+                    <person xml:id="contois" sex="MALE">
+                        <persName>Contois</persName>
                     </person>
                     <person xml:id="l-aisne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>L Aisne</persName>
@@ -486,7 +486,7 @@ le cadet, Dubois, laquais du cadet.</head>
 	<s n="1">Monsieur, je verrai.</s>
 </p>
                     </sp>
-<sp who="#monsieur-farnoze,-pret-a-sortir">
+<sp who="#monsieur-farnoze">
                         <speaker>MONSIEUR FARNOZE, prêt à sortir.</speaker>
                         <p n="10">
 	<s n="1">Ah ! </s>

--- a/tei/moissy-quiproquo.xml
+++ b/tei/moissy-quiproquo.xml
@@ -392,7 +392,7 @@ diner.</set>-->
 </div>
 <div type="scene" n="5">
                     <head>SCÈNE V. </head>
-<sp who="#le-laquais-seul,-les-regardant-aller">
+<sp who="#le-laquais">
                         <speaker>LE LAQUAIS seul, les regardant aller.</speaker>
                         <p n="1">
 	<s n="1">Voila deux jeunes gas assez bien tournés, Monsieur Guillot et Monsieur Pierrot seront un joli Laquais et un joli Soldat. </s>

--- a/tei/moliere-bourgeois-gentilhomme.xml
+++ b/tei/moliere-bourgeois-gentilhomme.xml
@@ -175,14 +175,17 @@
                     <person xml:id="italiens" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Italiens</persName>
                     </person>
-                    <person xml:id="le-musicien-itatien" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Musicien Itatien</persName>
+                    <person xml:id="le-musicien-italien" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Le Musicien Italien</persName>
                     </person>
                     <person xml:id="la-musicienne-italienne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>La Musicienne Italienne</persName>
                     </person>
                     <person xml:id="musicien-et-musicienne-italiens" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Musicien et Musicienne Italiens</persName>
+                    </person>
+                    <person xml:id="le-musicien-itatien" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Le Musicien Itatien</persName>
                     </person>
                     <person xml:id="musicien-musicienne-italiens" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Musicien Musicienne Italiens</persName>
@@ -7672,7 +7675,7 @@
                         <stage type="danse">Après l'air que la Musicienne a chanté, deux Scaramouches, deux Trivelins, et un Arlequin représentent une nuit à la manière des comédiens italiens, en cadence.</stage>
                         <stage type="sing">Un Musicien italien se joint à la Musicienne italienne, et chante avec elle les paroles qui suivent. </stage>
                     </sp>
-<sp who="#le-musicien-itatien">
+<sp who="#le-musicien-italien">
                         <speaker>LE MUSICIEN ITALIEN.</speaker>
                         <l n="266">Bel tempo che vola </l>
                         <l n="267">Rapisce il contento, </l>

--- a/tei/moliere-femmes-savantes.xml
+++ b/tei/moliere-femmes-savantes.xml
@@ -75,9 +75,6 @@
                     <person xml:id="l-epine" sex="MALE">
                         <persName>L'Epine</persName>
                     </person>
-                    <person xml:id="armande-et-belise" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Armande et Belise</persName>
-                    </person>
                     <person xml:id="vadius" sex="MALE">
                         <persName>Vadius</persName>
                     </person>
@@ -2130,7 +2127,7 @@
                         <speaker>PHILAMINTE.</speaker>
                         <l n="797">Mais en comprend-on bien, comme moi, la finesse ?</l>
                     </sp>
-<sp who="#armande-et-belise">
+<sp who="#armande #belise">
                         <speaker>ARMANDE et BÉLISE.</speaker>
                         <l n="798" part="I">Oh, oh.</l>
                     </sp>
@@ -2189,7 +2186,7 @@
 </lg>
 </ab>
                     </sp>
-<sp who="#philaminte #armande-et-belise">
+<sp who="#philaminte #armande #belise">
                         <speaker>PHILAMINTE, ARMANDE et BÉLISE.</speaker>
                         <l n="818"> Quoi qu'on die !</l>
                     </sp>
@@ -2201,7 +2198,7 @@
 </lg>
 </ab>
                     </sp>
-<sp who="#philaminte #armande-et-belise">
+<sp who="#philaminte #armande #belise">
                         <speaker>PHILAMINTE, ARMANDE et BÉLISE.</speaker>
                         <l n="820">Riche appartement !</l>
                     </sp>
@@ -2213,7 +2210,7 @@
 </lg>
 </ab>
                     </sp>
-<sp who="#philaminte #armande-et-belise">
+<sp who="#philaminte #armande #belise">
                         <speaker>PHILAMINTE, ARMANDE et BÉLISE.</speaker>
                         <l n="822">Cette ingrate de fièvre ?</l>
                     </sp>
@@ -2229,7 +2226,7 @@
                         <speaker>PHILAMINTE.</speaker>
                         <l n="824">Votre belle vie !</l>
                     </sp>
-<sp who="#armande-et-belise">
+<sp who="#armande #belise">
                         <speaker>ARMANDE et BÉLISE.</speaker>
                         <l n="825" part="I">Ah !</l>
                     </sp>
@@ -2242,7 +2239,7 @@
 </lg>
 </ab>
                     </sp>
-<sp who="#philaminte #armande-et-belise">
+<sp who="#philaminte #armande #belise">
                         <speaker>PHILAMINTE, ARMANDE et BÉLISE.</speaker>
                         <l n="827" part="I">Ah !</l>
                     </sp>
@@ -2369,7 +2366,7 @@
 </lg>
 </ab>
                     </sp>
-<sp who="#philaminte #armande-et-belise">
+<sp who="#philaminte #armande #belise">
                         <speaker>PHILAMINTE, ARMANDE et BÉLISE.</speaker>
                         <p n="1">
 	<s n="1">Ah !</s>

--- a/tei/moliere-malade-imaginaire.xml
+++ b/tei/moliere-malade-imaginaire.xml
@@ -71,9 +71,6 @@
                     <person xml:id="pan" sex="MALE">
                         <persName>Pan</persName>
                     </person>
-                    <person xml:id="flore-et-pan" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Flore et Pan</persName>
-                    </person>
                     <person xml:id="les-quatre-amants" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Quatre Amants</persName>
                     </person>
@@ -535,7 +532,7 @@
                         <speaker>TIRCIS et DORILAS.</speaker>
                         <l n="120">Ha ! Que d'un doux succès notre audace est suivie.</l>
                     </sp>
-<sp who="#flore-et-pan">
+<sp who="#flore #pan">
                         <speaker>FLORE et PAN.</speaker>
                         <l n="121">Ce qu'on fait pour LOUIS, on ne le perd jamais. </l>
                     </sp>
@@ -543,7 +540,7 @@
                         <speaker>LES QUATRE AMANTS.</speaker>
                         <l n="122">Au soin de ses plaisirs donnons-nous désormais. </l>
                     </sp>
-<sp who="#flore-et-pan">
+<sp who="#flore #pan">
                         <speaker>FLORE et PAN.</speaker>
                         <l n="123">Heureux, heureux, qui peut lui consacrer sa vie.</l>
                     </sp>

--- a/tei/moline-legislatrices.xml
+++ b/tei/moline-legislatrices.xml
@@ -47,17 +47,11 @@
                     <person xml:id="madame-clopin" sex="MALE">
                         <persName>Madame Clopin</persName>
                     </person>
-                    <person xml:id="madame-clopin-et-themire" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Madame Clopin et Themire</persName>
-                    </person>
                     <person xml:id="le-marquis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Marquis</persName>
                     </person>
                     <person xml:id="monsieur-clopin" sex="MALE">
                         <persName>Monsieur Clopin</persName>
-                    </person>
-                    <person xml:id="themire-et-madame-clopin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Themire et Madame Clopin</persName>
                     </person>
                     <person xml:id="julie" sex="MALE">
                         <persName>Julie</persName>
@@ -71,14 +65,8 @@
                     <person xml:id="le-depute" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Depute</persName>
                     </person>
-                    <person xml:id="madame-clopin-et-la-deputee" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Madame Clopin et la Deputee</persName>
-                    </person>
                     <person xml:id="madame-copin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Madame Copin</persName>
-                    </person>
-                    <person xml:id="le-marquis-et-monsieur-clopin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Marquis et Monsieur Clopin</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -168,7 +156,7 @@
                         <l n="3">Oui, nous en avons la puissance,</l>
                         <l n="4">Nous sommes dans l'indépendance.</l>
                     </sp>
-<sp who="#madame-clopin-et-themire">
+<sp who="#madame-clopin #themire">
                         <speaker>MADAME CLOPIN et THÉMIRE ensemble.</speaker>
                         <l n="5">Si le peuple ose en murmurer,</l>
                         <l n="6">Des hommes pour jamais il faut nous séparer.</l>
@@ -381,7 +369,7 @@
                         <l n="119">Eh vote, suivez-moi donc</l>
                         <l n="120">Où le devoir nous appelle.</l>
                     </sp>
-<sp who="#themire-et-madame-clopin">
+<sp who="#themire #madame-clopin">
                         <speaker>THÉMIRE et MADAME CLOPIN.</speaker>
                         <l n="121">Il a perdu la cervelle.</l>
                     </sp>
@@ -395,7 +383,7 @@
                         <speaker>LE MARQUIS.</speaker>
                         <l n="125">Je suis ravi de cela.</l>
                     </sp>
-<sp who="#themire-et-madame-clopin">
+<sp who="#themire #madame-clopin">
                         <speaker>THÉMIRE et MADAME CLOPIN.</speaker>
                         <l n="126">Bientôt on vous apprendra</l>
                         <l n="127">Qui de nous l'emportera.</l>
@@ -869,7 +857,7 @@
                         <l n="401">Hélas, quelle est ma disgrâce,</l>
                         <l n="402">Si je perds mon cher Lindor !</l>
                     </sp>
-<sp who="#madame-clopin-et-la-deputee">
+<sp who="#madame-clopin #la-deputee">
                         <speaker>MADAME CLOPIN et LA DEPUTÉE ensemble.</speaker>
                         <l n="403">Il faut qu'il meure,</l>
                         <l n="404">Et tout à l'heure</l>
@@ -1370,7 +1358,7 @@
                         <l n="611">Rassurez-vous, chère Julie :</l>
                         <l n="612">Lindor conservera vos jours.</l>
                     </sp>
-<sp who="#le-marquis-et-monsieur-clopin">
+<sp who="#le-marquis #monsieur-clopin">
                         <speaker>LE MARQUIS et MONSIEUR CLOPIN, à part.</speaker>
                         <stage type="together">Ensemble.</stage>
                         <l n="613">Qu'elles sont séduisantes,</l>

--- a/tei/monchretien-ecossaise-1604.xml
+++ b/tei/monchretien-ecossaise-1604.xml
@@ -38,7 +38,7 @@
                         </licence>
                     </availability>
                     <bibl type="originalSource">
-                        <idno type="URL">https://gallica.bnf.fr/ark:/12148/bpt6k64293528/f7.image.texteImage</idno>
+                        <idno type="URL">https://gallica.bnf.fr/ark:/12148/bpt6k10902663/f107.item</idno>
                     </bibl>
                 </bibl>
             </sourceDesc>
@@ -55,17 +55,14 @@
                     <person xml:id="choeur-des-etats" sex="MALE">
                         <persName>Choeur des Etats</persName>
                     </person>
-                    <person xml:id="davison" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Davison</persName>
+                    <person xml:id="davison" sex="MALE">
+                        <persName>D'Avison</persName>
                     </person>
-                    <person xml:id="suivantes-de-la-reine-d-ecosse-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Suivantes de la Reine D Ecosse</persName>
+                    <person xml:id="suivantes-de-la-reine-d-ecosse" sex="FEMALE">
+                        <persName>Choeur des Suivantes de la Reine d'Ecosse</persName>
                     </person>
                     <person xml:id="reine-d-ecosse" sex="FEMALE">
                         <persName>Reine d'Ecosse</persName>
-                    </person>
-                    <person xml:id="suivantes-de-la-reine-d-ecosse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Suivantes de la Reine D Ecosse</persName>
                     </person>
                     <person xml:id="page" sex="MALE">
                         <persName>Page</persName>
@@ -119,7 +116,7 @@
 			<castItem>
                     <role corresp="#conseiller">CONSEILLER</role>.</castItem>
 			<castItem>
-                    <role corresp="#d-avison">D'AVISON</role>.</castItem>
+                    <role corresp="#davison">D'AVISON</role>.</castItem>
 			<castItem>
                     <role corresp="#maitre-d-hotel">MAÎTRE D'HÔTEL</role>.</castItem>
 			<castItem>
@@ -129,7 +126,7 @@
 			<castItem>
                     <role corresp="#choeur-des-etats">CHOEUR DES ÉTATS</role>.</castItem>
  			<castItem>
-                    <role corresp="#choeur-des-suivantes-de-la-reine-d-ecosse">CHOEUR DES SUIVANTES DE LA REINE D'ÉCOSSE</role>.</castItem>
+                    <role corresp="#suivantes-de-la-reine-d-ecosse">CHOEUR DES SUIVANTES DE LA REINE D'ÉCOSSE</role>.</castItem>
 		</castList>
 		<!--TODO: usage of set in correct place but with unknown attributes <set location="Catharge" country="Tunisie" periode="Temps mythologiques" gps="(N/A)"/>-->
 		<note>Texte tiré de TRAGÉDIES DE MONTCHRESTIEN NOUVELLE ÉDITION AVEC NOTICE ET COMMENTAIRE PAR  L. PETIT DE JULLEVILLE PROFESSEUR A LA SORBONNE, 1604,  pp. 1-56 [BnF YF-2083-2084]</note>

--- a/tei/musset-la-coupe-et-les-levres.xml
+++ b/tei/musset-la-coupe-et-les-levres.xml
@@ -100,9 +100,6 @@
                     <person xml:id="tous" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous</persName>
                     </person>
-                    <person xml:id="le-peuple-et-les-soldats" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Peuple et les Soldats</persName>
-                    </person>
                     <person xml:id="deidamia" sex="FEMALE">
                         <persName>Déidamia</persName>
                     </person>
@@ -1836,7 +1833,7 @@
                         <l n="777" part="I">Allons, brisons ceci.</l>
                         <stage type="open">Il ouvre la bière.</stage>
                     </sp>
-<sp who="#le-peuple-et-les-soldats">
+<sp who="#le-peuple #les-soldats">
                         <speaker>LE PEUPLE ET LES SOLDATS.</speaker>
                         <l n="777" part="F">Moine, la bière est vide.</l>
                     </sp>

--- a/tei/nadal-epouse-du-cantique.xml
+++ b/tei/nadal-epouse-du-cantique.xml
@@ -56,23 +56,14 @@
                     <person xml:id="une-autre-fille-de-sion" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Une Autre Fille de Sion</persName>
                     </person>
-                    <person xml:id="choeur-des-filles-de-sion" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Choeur des Filles de Sion</persName>
-                    </person>
-                    <person xml:id="et-des-israelites" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Et des Israelites</persName>
+                    <person xml:id="le-choeur" sex="UNKNOWN">
+                        <persName>Le Choeur</persName>
                     </person>
                     <person xml:id="un-israelite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Israelite</persName>
                     </person>
                     <person xml:id="l-epoux" sex="MALE">
                         <persName>L'Epoux</persName>
-                    </person>
-                    <person xml:id="l-epoux-et-l-epouse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>L Epoux et L Epouse</persName>
-                    </person>
-                    <person xml:id="tout-le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Tout le Choeur</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -192,7 +183,7 @@
                         <l n="32">De son empire a fait dépendre,</l>
                         <l n="33">Le coeur de nos jeunes beautés.</l>
                     </sp>
-<sp who="#choeur-des-filles-de-sion #et-des-israelites">
+<sp who="#le-choeur">
                         <speaker>CHOEUR DES FILLES DE SION, ET DES ISRAÉLITES.</speaker>
                         <l n="34">Le bruit qu'a déjà su répandre</l>
                         <l n="35">Son nom sacré par toutes nos Cités,</l>
@@ -262,7 +253,7 @@
                         <l n="74">À la beauté tu joins les grâces,</l>
                         <l n="75">Présent le plus flatteur des Cieux.</l>
                     </sp>
-<sp who="#l-epoux-et-l-epouse">
+<sp who="#l-epoux #l-epouse">
                         <speaker>L'ÉPOUX ET L'ÉPOUSE.</speaker>
                         <l n="76">Non, Il n'est rien que tu n'effaces,</l>
                         <l n="77">Dans tout ce qui brille à mes yeux.</l>
@@ -306,7 +297,7 @@
                         <l n="100">Entre les bras d'une épouse si chère,</l>
                         <l n="101">Dans un sommeil divin se perdent ses transports.</l>
                     </sp>
-<sp who="#choeur-des-filles-de-sion">
+<sp who="#le-choeur">
                         <speaker>CHOEUR DES FILLES DE SION.</speaker>
                         <l n="102">Quel est cet auguste mystère ?</l>
                         <l n="103">Son Roi verse en son sein les plus riches trésors.</l>
@@ -347,7 +338,7 @@
                         <l n="127">Que tout notre bonheur se fonde.</l>
                         <l n="128">D'un feu si pur dépend le sort du monde.</l>
                     </sp>
-<sp who="#tout-le-choeur">
+<sp who="#le-choeur">
                         <speaker>CHOEUR DES ISRAéLITES ET DES FILLES DE SION.	</speaker>
                         <l n="129">Puisse à jamais, de ta gloire jaloux,</l>
                         <l n="130">Le Ciel dans une paix profonde</l>

--- a/tei/nadal-esther.xml
+++ b/tei/nadal-esther.xml
@@ -48,8 +48,8 @@
                     <person xml:id="un-israelite" sex="MALE">
                         <persName>Un Israélite</persName>
                     </person>
-                    <person xml:id="un-israelite-et-une-fille-israelite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Un Israelite et une Fille Israelite</persName>
+                    <person xml:id="une-fille-israelite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Une Fille Israelite</persName>
                     </person>
                     <person xml:id="le-choeur" sex="UNKNOWN">
                         <persName>Le Choeur</persName>
@@ -165,7 +165,7 @@
                         <l n="11">Dieu qui veille, et pour lui tôt ou tard se déclare,</l>
                         <l n="12">Fait servir la beauté d'ESTHER.</l>
                     </sp>
-<sp who="#un-israelite-et-une-fille-israelite">
+<sp who="#un-israelite #une-fille-israelite">
                         <speaker>UN ISRAÉLITE ET UNE FILLE ISRAÉLITE.</speaker>
                         <l n="13">De la beauté chantons les charmes,</l>
                         <l n="14">C'est de tout un peuple en alarmes</l>

--- a/tei/nadal-paradis-terrestre.xml
+++ b/tei/nadal-paradis-terrestre.xml
@@ -57,17 +57,11 @@
                     <person xml:id="l-ange" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>L Ange</persName>
                     </person>
-                    <person xml:id="adam-et-eve" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Adam et Eve</persName>
-                    </person>
                     <person xml:id="choeur" sex="UNKNOWN">
                         <persName>Choeur des Anges</persName>
                     </person>
                     <person xml:id="voix-du-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Voix du Choeur</persName>
-                    </person>
-                    <person xml:id="adam_eve" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Adam_eve</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -282,7 +276,7 @@
                         <l n="98">En me donnant ton coeur il a plus fait pour moi.</l>
                         <stage type="together">DUO.</stage>
                     </sp>
-<sp who="#adam-et-eve">
+<sp who="#adam #eve">
                         <speaker>ADAM, ÈVE.</speaker>
                         <l n="99">Pour hâter un bonheur suprême,</l>
                         <l n="100">Serments sacrés, unissez nos destins :</l>
@@ -360,7 +354,7 @@
                         <l n="150">Rendait ainsi leurs voeux et leurs tendres soupirs.</l>
                         <stage type="together">DUO.</stage>
                     </sp>
-<sp who="#adam_eve">
+<sp who="#adam #eve">
                         <speaker>ADAM et ÈVE.</speaker>
                         <l n="151">Puisse pour nous le Dieu qui comble nos désirs,</l>
                         <l n="152">Charmant époux être toujours le même.</l>

--- a/tei/nericault-glorieux.xml
+++ b/tei/nericault-glorieux.xml
@@ -77,9 +77,6 @@
                     <person xml:id="monsieur-josse" sex="MALE">
                         <persName>Monsieur Josse</persName>
                     </person>
-                    <person xml:id="valere-et-isabelle" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Valere et Isabelle</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -5848,7 +5845,7 @@
                         <speaker>LYCANDRE, au Comte.</speaker>
                         <l n="2039" part="I">Je viens savoir, mon fils... </l>
                     </sp>
-<sp who="#valere-et-isabelle">
+<sp who="#valere #isabelle">
                         <speaker>VALÈRE et ISABELLE.</speaker>
                         <l n="2039" part="M">Son fils ! </l>
                     </sp>

--- a/tei/nivelle-ecole-meres.xml
+++ b/tei/nivelle-ecole-meres.xml
@@ -71,11 +71,11 @@
                     <person xml:id="le-suisse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Suisse</persName>
                     </person>
-                    <person xml:id="numer-laquais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numer Laquais</persName>
+                    <person xml:id="laquais-1er" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Laquais 1er</persName>
                     </person>
-                    <person xml:id="numeme-laquais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numeme Laquais</persName>
+                    <person xml:id="laquais-2eme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Laquais 2eme</persName>
                     </person>
                     <person xml:id="le-coureur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Coureur</persName>
@@ -1875,11 +1875,11 @@
                         <speaker>Le SUISSE.</speaker>
                         <l n="633" part="F">J'attends votre réponse.</l>
                     </sp>
-<sp who="#numer-laquais">
+<sp who="#laquais-1er">
                         <speaker>Un Laquais, à son camarade.</speaker>
                         <l n="634" part="I">Connais-tu ça ?</l>
                     </sp>
-<sp who="#numeme-laquais">
+<sp who="#laquais-2eme">
                         <speaker>Un Autre Laquais.</speaker>
                         <l n="634" part="F">Moi ! Ma foi, non.</l>
                     </sp>

--- a/tei/nivelle-prejuge-a-la-mode.xml
+++ b/tei/nivelle-prejuge-a-la-mode.xml
@@ -68,9 +68,6 @@
                     <person xml:id="damis" sex="MALE">
                         <persName>Damis</persName>
                     </person>
-                    <person xml:id="durval_argant_damon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Durval_argant_damon</persName>
-                    </person>
                     <person xml:id="henri" sex="MALE">
                         <persName>Henri</persName>
                     </person>
@@ -1804,7 +1801,7 @@
                         <l n="676" part="F">Autant vaut ;</l>
                         <l n="677" part="I">Il est amoureux fou.</l>
                     </sp>
-<sp who="#durval_argant_damon">
+<sp who="#durval #argant #damon">
                         <speaker>TOUS, c'est-à-dire, Durval, Argant, Damon.</speaker>
                         <l n="677" part="M">De qui ?</l>
                     </sp>

--- a/tei/onhet-aux-avants-postes.xml
+++ b/tei/onhet-aux-avants-postes.xml
@@ -52,9 +52,6 @@
                     <person xml:id="gaston" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Gaston</persName>
                     </person>
-                    <person xml:id="diane-et-gaston" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Diane et Gaston</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -505,7 +502,7 @@
                         <speaker>DIANE, levant son verre.</speaker>
                         <l n="161">Monsieur, je suis Française, et bois à la victoire !</l>
                     </sp>
-<sp who="#diane-et-gaston">
+<sp who="#diane #gaston">
                         <speaker>DIANE et GASTON, se levant ensemble.</speaker>
                         <l n="162" part="I">À la victoire !</l>
                     </sp>

--- a/tei/panard-critique-a-l-opera-comique.xml
+++ b/tei/panard-critique-a-l-opera-comique.xml
@@ -45,23 +45,20 @@
         <profileDesc>
             <particDesc>
                 <listPerson>
-                    <person xml:id="mademoiselle-raimond" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Mademoiselle Raimond</persName>
+                    <person xml:id="mademoiselle-raimond" sex="FEMALE">
+                        <persName>Mlle. Raimond</persName>
                     </person>
-                    <person xml:id="l-acteur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>L Acteur</persName>
+                    <person xml:id="l-acteur" sex="MALE">
+                        <persName>Un Acteur</persName>
                     </person>
-                    <person xml:id="le-procureur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Procureur</persName>
+                    <person xml:id="le-procureur" sex="MALE">
+                        <persName>Un Procureur</persName>
                     </person>
-                    <person xml:id="le-gascon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Gascon</persName>
+                    <person xml:id="le-gascon" sex="MALE">
+                        <persName>Un Gascon</persName>
                     </person>
                     <person xml:id="monsieur-clamart" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Monsieur Clamart</persName>
-                    </person>
-                    <person xml:id="tous-deux" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Tous Deux</persName>
                     </person>
                     <person xml:id="la-critique" sex="FEMALE">
                         <persName>La Critique</persName>
@@ -124,15 +121,13 @@
 		<castList>
                 <head>ACTEURS.</head>
 			<castItem>
-                    <role corresp="#empty-string">JULIE</role>.</castItem>
+                    <role corresp="#mademoiselle-raimond">MLLE. RAIMOND</role>.</castItem>
 			<castItem>
-                    <role corresp="#empty-string">RAIMOND</role>.</castItem>
+                    <role corresp="#l-acteur">UN ACTEUR</role>.</castItem>
 			<castItem>
-                    <role corresp="#empty-string">UN ACTEUR</role>.</castItem>
+                    <role corresp="#le-procureur">UN PROCUREUR</role>.</castItem>
 			<castItem>
-                    <role corresp="#empty-string">UN PROCUREUR</role>.</castItem>
-			<castItem>
-                    <role corresp="#un-gascon">UN GASCON</role>.</castItem>
+                    <role corresp="#le-gascon">UN GASCON</role>.</castItem>
 			<castItem>
                     <role corresp="#un-medecin">UN MÉDECIN</role>.</castItem>
 			<castItem>
@@ -148,7 +143,7 @@
 	<note>Texte tiré de "Théâtre et Oeuvres diverses de M. Panard", Paris, Duschene, 1763. pp 259-298.</note>
 </front>
 <body>
-<div type="cte" n="1">
+<div type="acte" n="1">
                 <head>LA CRITIQUE À L'OPÉRA-COMIQUE</head>
 <div type="scene" n="1">
                     <head>SCÈNE PREMIÈRE. Mademoiselle Raimond, Un acteur.</head>
@@ -798,7 +793,7 @@
                         <l n="135">Soulagez la tristesse</l>
                         <l n="136">Qui nous accable tous. </l>
                     </sp>
-<sp who="#tous-deux">
+<sp who="#mademoiselle-raimond #l-acteur">
                         <speaker>TOUS DEUX.</speaker>
                         <l n="137">Déesse, Déesse,</l>
                         <l n="138">Nous languissons sans vous.</l>

--- a/tei/panard-le-magasin-des-modernes.xml
+++ b/tei/panard-le-magasin-des-modernes.xml
@@ -57,7 +57,7 @@
                     <person xml:id="le-poete" sex="MALE">
                         <persName>Le Poète</persName>
                     </person>
-                    <person xml:id="merveilleux" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                    <person xml:id="merveilleux" sex="MALE">
                         <persName>Merveilleux</persName>
                     </person>
                     <person xml:id="la-rime" sex="FEMALE">
@@ -124,7 +124,7 @@
 			<castItem>
                     <role corresp="#le-compositeur">LE COMPOSITEUR</role>.</castItem>
 			<castItem>
-                    <role corresp="#empty-string">MERVEILLEUX</role>, en folle.</castItem>
+                    <role corresp="#merveilleux">MERVEILLEUX</role>, en folle.</castItem>
 		</castList>
 	<!--TODO: usage of set in correct place but with unknown attributes <set location="Paris" country="France" periode="XVIIIème" gps="48.856614, 2.352222">La Scène est à l'Opéra.</set>-->
 </front>

--- a/tei/piis-cassandre-astrologue.xml
+++ b/tei/piis-cassandre-astrologue.xml
@@ -62,9 +62,6 @@
                     <person xml:id="cassandre" sex="MALE">
                         <persName>Cassandre</persName>
                     </person>
-                    <person xml:id="cassandre-et-isabelle" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Cassandre et Isabelle</persName>
-                    </person>
                     <person xml:id="ensemble" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Ensemble</persName>
                     </person>
@@ -950,7 +947,7 @@
                         <l n="403">C'est de voir ce qu'on aime !</l>
                         <l n="404">C'est de tout mon coeur ;</l>
                     </sp>
-<sp who="#cassandre-et-isabelle">
+<sp who="#cassandre #isabelle">
                         <speaker>CASSANDRE et ISABELLE, à part.</speaker>
                         <l n="405">Moi de même.</l>
                     </sp>
@@ -999,7 +996,7 @@
                         <speaker>LÉANDRE.</speaker>
                         <l n="417">De nous réunir ;</l>
                     </sp>
-<sp who="#cassandre-et-isabelle">
+<sp who="#cassandre #isabelle">
                         <speaker>CASSANDRE et ISABELLE, à part.</speaker>
                         <l n="418">Moi de même.</l>
                     </sp>

--- a/tei/piron-ecole-peres.xml
+++ b/tei/piron-ecole-peres.xml
@@ -71,17 +71,8 @@
                     <person xml:id="damis" sex="MALE">
                         <persName>Damis</persName>
                     </person>
-                    <person xml:id="premier-laquais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Premier Laquais</persName>
-                    </person>
-                    <person xml:id="eraste-damis-valere" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Eraste Damis Valere</persName>
-                    </person>
-                    <person xml:id="eraste_damis_valere" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Eraste_damis_valere</persName>
-                    </person>
-                    <person xml:id="eraste-damis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Eraste Damis</persName>
+                    <person xml:id="laquais" sex="MALE">
+                        <persName>Laquais</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -2447,7 +2438,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="893" part="I">Coquins ! à peu ne tient...</l>
                     </sp>
-<sp who="#premier-laquais">
+<sp who="#laquais">
                         <speaker>PREMIER LAQUAIS.</speaker>
                         <l n="893" part="M">Mais, c'est vous qui...</l>
                     </sp>
@@ -2477,7 +2468,7 @@
                         <speaker>ÉRASTE.</speaker>
                         <l n="900">Nous ! Donner à la porte un pareil ordre !</l>
                     </sp>
-<sp who="#eraste-damis-valere">
+<sp who="#eraste #damis #valere">
                         <speaker>Tous trois.</speaker>
                         <l n="901" part="I">Nous !</l>
                     </sp>
@@ -2764,7 +2755,7 @@
                         <l n="1025">Il m'évite ! Avouez que vous n'attendiez guère</l>
                         <l n="1026">La proposition qu'il avait à vous faire.</l>
                     </sp>
-<sp who="#eraste_damis_valere">
+<sp who="#eraste #damis #valere">
                         <speaker>Tous trois.</speaker>
                         <l n="1027" part="I">Ma foi non, mon oncle.</l>
                     </sp>
@@ -3519,7 +3510,7 @@
                         <l n="1296" part="F">Comment diable !</l>
                         <l n="1297" part="I">Tous trois ?</l>
                     </sp>
-<sp who="#eraste-damis">
+<sp who="#eraste #damis">
                         <speaker>ÉRASTE et DAMIS, à part.</speaker>
                         <l n="1297" part="M">Autre fâcheux !</l>
                     </sp>
@@ -3650,7 +3641,7 @@
                         <speaker>GRÉGOIRE.</speaker>
                         <l n="1322" part="I">Oui da ! Vou trouvé ça...</l>
                     </sp>
-<sp who="#eraste_damis_valere">
+<sp who="#eraste #damis #valere">
                         <speaker>Tous trois.</speaker>
                         <l n="1322" part="M">très mal !</l>
                     </sp>
@@ -4343,7 +4334,7 @@
                         <l n="1613" part="F">Eh bien donc, je vous dis</l>
                         <l n="1614">Que, si je l'avais pu, j'aurais fait cent fois pis.</l>
                     </sp>
-<sp who="#eraste_damis_valere">
+<sp who="#eraste #damis #valere">
                         <speaker>Tous trois.</speaker>
                         <l n="1615" part="I">Fort bien.</l>
                     </sp>

--- a/tei/piron-fausse-alarme.xml
+++ b/tei/piron-fausse-alarme.xml
@@ -58,9 +58,6 @@
                     <person xml:id="lysis" sex="MALE">
                         <persName>Lysis</persName>
                     </person>
-                    <person xml:id="sylvie_lysis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Sylvie_lysis</persName>
-                    </person>
                     <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Choeur</persName>
                     </person>
@@ -318,7 +315,7 @@
                         <l n="112">Demain vous serez obéie ;</l>
                         <l n="113">Demain, pour jamais je le fuis.</l>
                     </sp>
-<sp who="#sylvie_lysis">
+<sp who="#sylvie #lysis">
                         <speaker>Ensemble.</speaker>
                         <l n="114">Loin de nous tout volage</l>
                         <l n="115">Qui nomme esclavage</l>

--- a/tei/plaute-casina.xml
+++ b/tei/plaute-casina.xml
@@ -67,9 +67,6 @@
                     <person xml:id="le-cuisinier" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Cuisinier</persName>
                     </person>
-                    <person xml:id="olympion-et-stalinon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Olympion et Stalinon</persName>
-                    </person>
                     <person xml:id="une-servante" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Une Servante</persName>
                     </person>
@@ -3611,7 +3608,7 @@
 	<s n="1">À merveille, et je t'aiderai, puisque nous épousons tous les deux.</s>
 </p>
                     </sp>
-<sp who="#olympion-et-stalinon">
+<sp who="#olympion #stalinon">
                         <speaker>OLYMPION et STALINON. </speaker>
                         <p n="9">
 	<s n="1">Ô hymen ! </s>

--- a/tei/poisson-sot-venge.xml
+++ b/tei/poisson-sot-venge.xml
@@ -55,9 +55,6 @@
                     <person xml:id="lubin" sex="MALE">
                         <persName>Lubin</persName>
                     </person>
-                    <person xml:id="lubin_lubine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Lubin_lubine</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -1268,7 +1265,7 @@
                         <l n="520">Mais jamais, jamais,</l>
                         <l n="521">Tu ne m'endormiras.</l>
                     </sp>
-<sp who="#lubin_lubine">
+<sp who="#lubin #lubine">
                         <speaker>LUBIN et LUBINE chantent.</speaker>
                         <l n="522">Ah, le bon vin ! </l>
                         <l n="523">Tu as endormi ma mère,</l>

--- a/tei/quinault-alceste.xml
+++ b/tei/quinault-alceste.xml
@@ -76,9 +76,6 @@
                     <person xml:id="la-nymphe-de-la-marne" sex="FEMALE">
                         <persName>La Nymphe de la Marne</persName>
                     </person>
-                    <person xml:id="et-la-nymphe-de-la-seine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Et la Nymphe de la Seine</persName>
-                    </person>
                     <person xml:id="la-nymphe-de-la-tuileries" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>La Nymphe de la Tuileries</persName>
                     </person>
@@ -129,9 +126,6 @@
                     </person>
                     <person xml:id="soldats" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Soldats</persName>
-                    </person>
-                    <person xml:id="et-straton" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Et Straton</persName>
                     </person>
                     <person xml:id="les-assiegeants" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Assiegeants</persName>
@@ -501,7 +495,7 @@
                         <l n="58">Que le doux penchant des Amours ? </l>
                         <stage type="danse">On danse.</stage>
                     </sp>
-<sp who="#la-gloire #et-la-nymphe-de-la-seine">
+<sp who="#la-gloire #la-nymphe-de-la-seine">
                         <speaker>LA GLOIRE, et LA NYMPHE DE LA SEINE.</speaker>
                         <l n="59">Que tout retentisse, </l>
                         <l n="60">Que tout réponde à nos voix. </l>
@@ -1328,7 +1322,7 @@
                         <speaker>ADMÈTE, et ALCIDE.</speaker>
                         <l n="457">À l'assaut, à l'assaut. </l>
                     </sp>
-<sp who="#licomede #et-straton">
+<sp who="#licomede #straton">
                         <speaker>LICOMÈDE, et STRATON.</speaker>
                         <l n="458">Aux Armes, aux Armes.</l>
                     </sp>

--- a/tei/quinault-amadis.xml
+++ b/tei/quinault-amadis.xml
@@ -43,23 +43,20 @@
         <profileDesc>
             <particDesc>
                 <listPerson>
-                    <person xml:id="urgande-et-alquif" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Urgande et Alquif</persName>
-                    </person>
-                    <person xml:id="les-suivants-d-alquif-et-les-suivantes-d-urgande" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Les Suivants D Alquif et les Suivantes D Urgande</persName>
-                    </person>
-                    <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Choeur</persName>
-                    </person>
                     <person xml:id="urgande" sex="FEMALE">
                         <persName>Urgande</persName>
                     </person>
                     <person xml:id="alquif" sex="MALE">
                         <persName>Alquif</persName>
                     </person>
-                    <person xml:id="urgande-et-le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Urgande et le Choeur</persName>
+                    <person xml:id="les-suivants-d-alquif" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Suivants D Alquif</persName>
+                    </person>
+                    <person xml:id="les-suivantes-d-urgande" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Suivantes D Urgande</persName>
+                    </person>
+                    <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Le Choeur</persName>
                     </person>
                     <person xml:id="florestan" sex="MALE">
                         <persName>Florestan</persName>
@@ -69,9 +66,6 @@
                     </person>
                     <person xml:id="corisande" sex="FEMALE">
                         <persName>Corisande</persName>
-                    </person>
-                    <person xml:id="corisande-et-florestan" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Corisande et Florestan</persName>
                     </person>
                     <person xml:id="oriane" sex="FEMALE">
                         <persName>Oriane</persName>
@@ -85,14 +79,14 @@
                     <person xml:id="arcalaüs" sex="MALE">
                         <persName>Arcalaüs</persName>
                     </person>
-                    <person xml:id="arcabonne-et-arcalaüs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Arcabonne et Arcalaüs</persName>
-                    </person>
                     <person xml:id="deux-bergeres" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Deux Bergeres</persName>
                     </person>
-                    <person xml:id="un-berger-et-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Un Berger et Choeur</persName>
+                    <person xml:id="un-berger" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Un Berger</persName>
+                    </person>
+                    <person xml:id="choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Choeur</persName>
                     </person>
                     <person xml:id="choeur-des-captives-et-des-captifs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Captives et des Captifs</persName>
@@ -102,15 +96,6 @@
                     </person>
                     <person xml:id="l-ombre-d-ardan-canile" sex="MALE">
                         <persName>L'Ombre d'Ardan Canile</persName>
-                    </person>
-                    <person xml:id="les-suivantes-d-urgande" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Les Suivantes D Urgande</persName>
-                    </person>
-                    <person xml:id="oriane-et-amadis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Oriane et Amadis</persName>
-                    </person>
-                    <person xml:id="corisande-et-le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Corisande et le Choeur</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -218,19 +203,19 @@
 <stage type="decor/sleep/meteo/awake">Le théâtre représente les lieux qu'Urgande et Alquif ont choisis, pour y demeurer enchantés et assoupis avec leur suite. Un éclair et un coup de tonnerre commencent à dissiper l'assoupissement d'Urgande, d'Alquif et de leur suite.</stage>
 <div type="scene" n="1">
                     <head>OUVERTURE.</head>
-<sp who="#urgande-et-alquif">
+<sp who="#urgande #alquif">
                         <speaker>URGANDE ET ALQUIF sous un riche pavillon.</speaker>
                         <l n="1">Ah j'entends un bruit qui nous presse</l>
                         <l n="2">De nous rassembler tous,</l>
                         <l n="3">Le charme cesse</l>
                         <l n="4">Éveillons-nous.</l>
                     </sp>
-<sp who="#les-suivants-d-alquif-et-les-suivantes-d-urgande">
+<sp who="#les-suivants-d-alquif #les-suivantes-d-urgande">
                         <speaker>LES SUIVANTS D'ALQUIF ET LES SUIVANTES D'URGANDE, s'éveillent et répètent ces deux vers.</speaker>
                         <l n="5">Le charme cesse...</l>
                         <l n="6">Éveillons-nous.</l>
                     </sp>
-<sp who="#urgande-et-alquif">
+<sp who="#urgande #alquif">
                         <speaker>URGANDE ET ALQUIF.</speaker>
                         <l n="7">Esprits, empressés à nous plaire,</l>
                         <l n="8">Vous, qui veillez ici pour notre sûreté,</l>
@@ -284,7 +269,7 @@
                         <l n="42">D'un mot, d'un seul de ses regards</l>
                         <l n="43">Il sait rendre, à son gré, leur fureur inutile.</l>
                     </sp>
-<sp who="#urgande-et-alquif">
+<sp who="#urgande #alquif">
                         <speaker>URGANDE ET ALQUIF.</speaker>
                         <l n="44">C'est à lui d'enseigner </l>
                         <l n="45">Aux maîtres de la terre</l>
@@ -313,7 +298,7 @@
                         <l n="59">D'un roi, l'étonnement des rois,</l>
                         <l n="60">Et des plus grands héros le plus parfait modèle.</l>
                     </sp>
-<sp who="#urgande-et-alquif">
+<sp who="#urgande #alquif">
                         <speaker>URGANDE ET ALQUIF.</speaker>
                         <l n="61">Tout l'univers admire ses exploits ;</l>
                         <l n="62">Allons vivre heureux sous ses lois.</l>
@@ -324,7 +309,7 @@
                         <l n="64">Allons vivre heureux sous ses lois.</l>
                         <stage type="danse">On danse.</stage>
                     </sp>
-<sp who="#urgande-et-le-choeur">
+<sp who="#urgande #le-choeur">
                         <speaker>URGANDE ET LE CHOEUR.</speaker>
                         <l n="65">Suivons l'amour, c'est lui qui nous mène ;</l>
                         <l n="66">Tout doit sentir son aimable ardeur.</l>
@@ -336,7 +321,7 @@
                         <l n="72">Que l'embarras de garder notre coeur.</l>
                         <stage type="danse">On danse.</stage>
                     </sp>
-<sp who="#urgande-et-alquif">
+<sp who="#urgande #alquif">
                         <speaker>URGANDE ET ALQUIF.</speaker>
                         <l n="73">Volez, tendres amours, Amadis va revivre.</l>
                         <l n="74">Son grand coeur est fait pour vous suivre.</l>
@@ -474,7 +459,7 @@
                         <speaker>FLORESTAN.</speaker>
                         <l n="133" part="M">Corisande !</l>
                     </sp>
-<sp who="#corisande-et-florestan">
+<sp who="#corisande #florestan">
                         <speaker>CORISANDE ET FLORESTAN.</speaker>
                         <l n="133" part="F">Ô bienheureux moment </l>
                         <l n="134">Qui finit mon cruel tourment !</l>
@@ -497,7 +482,7 @@
                         <l n="142">Aimons-nous, belle Corisande,</l>
                         <l n="143">Et comptons la grandeur pour rien.</l>
                     </sp>
-<sp who="#corisande-et-florestan">
+<sp who="#corisande #florestan">
                         <speaker>CORISANDE ET FLORESTAN.</speaker>
                         <l n="144">Vous êtes le seul bien</l>
                         <l n="145">Que mon amour demande.</l>
@@ -731,7 +716,7 @@
                         <speaker>ARCALAÜS.</speaker>
                         <l n="260">Que j'aime à voir en vous ce généreux transport !</l>
                     </sp>
-<sp who="#arcabonne-et-arcalaüs">
+<sp who="#arcabonne #arcalaüs">
                         <speaker>ARCABONNE ET ARCALAÜS.</speaker>
                         <l n="261">Irritons notre barbarie :</l>
                         <l n="262">Écoutons notre sang qui crie :</l>
@@ -892,7 +877,7 @@
                         <l n="326">Au charme de la beauté.</l>
                         <stage type="danse">On danse</stage>
                     </sp>
-<sp who="#deux-bergeres #un-berger-et-choeur">
+<sp who="#deux-bergeres #un-berger #choeur">
                         <speaker>DEUX BERGÈRES, UN BERGER alternativement avec le CHOEUR.</speaker>
                         <l n="327">Vous ne devez plus attendre</l>
                         <l n="328">Rien qui trouble vos désirs.</l>
@@ -1083,7 +1068,7 @@
                         <speaker>FLORESTAN.</speaker>
                         <l n="420">Aimons-nous, livrons-nous au bonheur de nous voir.</l>
                     </sp>
-<sp who="#corisande-et-florestan">
+<sp who="#corisande #florestan">
                         <speaker>CORISANDE ET FLORESTAN.</speaker>
                         <l n="421">L'amour et la victoire</l>
                         <l n="422">S'unissent, pour nous rendre heureux.</l>
@@ -1303,7 +1288,7 @@
 </div>
 <div type="scene" n="5">
                     <head>SCÈNE V. Arcalaüs, Arcabonne, Amadis qui paraît mort, Oriane, évanouie.</head>
-<sp who="#arcabonne-et-arcalaüs">
+<sp who="#arcabonne #arcalaüs">
                         <speaker>ARCABONNE ET ARCALAÜS.</speaker>
                         <l n="538">Quel plaisir de voir </l>
                         <l n="539">Un si cruel désespoir !</l>
@@ -1319,7 +1304,7 @@
                         <l n="543">Il faut faire de leur amour</l>
                         <l n="544">Le ministre de notre haine.</l>
                     </sp>
-<sp who="#arcabonne-et-arcalaüs">
+<sp who="#arcabonne #arcalaüs">
                         <speaker>ARCABONNE ET ARCALAÜS.</speaker>
                         <l n="545">Quel plaisir de voir</l>
                         <l n="546">Un si cruel désespoir!</l>
@@ -1356,7 +1341,7 @@
                         <l n="564">Ces fidèles amants en paix.</l>
                         <stage type="magic">Urgande touche de sa baguette Arcalaüs et Arcabonne.</stage>
                     </sp>
-<sp who="#arcabonne-et-arcalaüs">
+<sp who="#arcabonne #arcalaüs">
                         <speaker>ARCABONNE ET ARCALAÜS.</speaker>
                         <l n="565">Tout mon effort est inutile,</l>
                         <l n="566">Je demeure immobile ;</l>
@@ -1400,7 +1385,7 @@
 </ab>
                         <stage type="entrance/fly/down/fight">Les démons des enfers sortent pour secourir Arcalaüs, et Arcabonne. Les démons de l'air viennent combattre contre ceux des enfers et les surmontent.</stage>
                     </sp>
-<sp who="#arcabonne-et-arcalaüs">
+<sp who="#arcabonne #arcalaüs">
                         <speaker>ARCABONNE ET ARCALAÜS.</speaker>
                         <l n="586">On brave notre vain pouvoir,</l>
                         <l n="587">Tout est contraire à notre envie :</l>
@@ -1483,7 +1468,7 @@
                         <l n="618">Pour me faire sentir la perte que je fais !</l>
                         <l n="619">Mes yeux, mes tristes yeux, fermez-vous pour jamais.</l>
                     </sp>
-<sp who="#oriane-et-amadis">
+<sp who="#oriane #amadis">
                         <speaker>ORIANE ET AMADIS.</speaker>
                         <l n="620">Ô ciel ! Le puis-je croire ?</l>
                     </sp>
@@ -1504,7 +1489,7 @@
                         <speaker>AMADIS.</speaker>
                         <l n="623" part="F">Puis-je encore vivre en votre mémoire ?</l>
                     </sp>
-<sp who="#oriane-et-amadis">
+<sp who="#oriane #amadis">
                         <speaker>ORIANE ET AMADIS.</speaker>
                         <l n="624">Ô Ciel ! Le puis-je croire !</l>
                     </sp>
@@ -1544,7 +1529,7 @@
                         <l n="644">Tout vous a dit</l>
                         <l n="645">Que je vous aime.</l>
                     </sp>
-<sp who="#oriane-et-amadis">
+<sp who="#oriane #amadis">
                         <speaker>ORIANE ET AMADIS.</speaker>
                         <l n="646">Je vous promets</l>
                         <l n="647">De n'éteindre jamais</l>
@@ -1564,7 +1549,7 @@
                         <l n="654">Vous donne encor de la puissance.</l>
                         <stage type="danse">On danse.</stage>
                     </sp>
-<sp who="#corisande-et-le-choeur">
+<sp who="#corisande #le-choeur">
                         <speaker>CORISANDE ET LE CHOEUR.</speaker>
                         <l n="655">D'un bonheur nouveau </l>
                         <l n="656">Goûtons tous les charmes ;</l>
@@ -1578,7 +1563,7 @@
                         <l n="661">Enchaînez la victoire ;</l>
                         <l n="662">Donnez à jamais de beaux jours.</l>
                     </sp>
-<sp who="#corisande-et-le-choeur">
+<sp who="#corisande #le-choeur">
                         <speaker>CORISANDE ET LE CHOEUR.</speaker>
                         <l n="663">D'un bonheur nouveau </l>
                         <l n="664">Goûtons tous les charmes ;</l>
@@ -1586,7 +1571,7 @@
                         <l n="666">Et l'Amour sans bandeau.</l>
                     </sp>
 <stage type="danse">On danse.</stage>
-<sp who="#corisande-et-le-choeur">
+<sp who="#corisande #le-choeur">
                         <speaker>CORISANDE ET LE CHOEUR.</speaker>
                         <l n="667">Aimable maître</l>
                         <l n="668">De nos désirs,</l>

--- a/tei/quinault-armide.xml
+++ b/tei/quinault-armide.xml
@@ -51,11 +51,11 @@
                     <person xml:id="la-sagesse" sex="FEMALE">
                         <persName>La Sagesse</persName>
                     </person>
-                    <person xml:id="la-sagesse-et-sa-suite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Sagesse et sa Suite</persName>
+                    <person xml:id="troupe-de-nymphes" sex="UNKNOWN">
+                        <persName>Troupe de Nymphes</persName>
                     </person>
-                    <person xml:id="la-gloire-et-sa-suite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Gloire et sa Suite</persName>
+                    <person xml:id="troupe-de-heros" sex="UNKNOWN">
+                        <persName>Troupe de Heros</persName>
                     </person>
                     <person xml:id="les-choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Choeurs</persName>
@@ -249,11 +249,11 @@
                         <l n="11">Tout doit céder dans l'Univers</l>
                         <l n="12">À l'Auguste Héros que j'aime.</l>
                     </sp>
-<sp who="#la-sagesse-et-sa-suite">
+<sp who="#la-sagesse #troupe-de-nymphes">
                         <speaker>LA SAGESSE et sa suite.</speaker>
                         <l n="13">Chantons la douceur de ses lois.</l>
                     </sp>
-<sp who="#la-gloire-et-sa-suite">
+<sp who="#la-gloire #troupe-de-heros">
                         <speaker>LA GLOIRE et sa suite.</speaker>
                         <l n="14">Chantons ses glorieux exploits. </l>
                     </sp>

--- a/tei/quinault-atys.xml
+++ b/tei/quinault-atys.xml
@@ -54,9 +54,6 @@
                     <person xml:id="flore" sex="FEMALE">
                         <persName>Flore</persName>
                     </person>
-                    <person xml:id="temps_flore" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Temps_flore</persName>
-                    </person>
                     <person xml:id="zephir" sex="UNKNOWN">
                         <persName>Zéphir</persName>
                     </person>
@@ -65,9 +62,6 @@
                     </person>
                     <person xml:id="iris" sex="FEMALE">
                         <persName>Iris</persName>
-                    </person>
-                    <person xml:id="melpomene_flore" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Melpomene_flore</persName>
                     </person>
                     <person xml:id="le-temps" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Temps</persName>
@@ -90,15 +84,6 @@
                     <person xml:id="doris" sex="FEMALE">
                         <persName>Doris</persName>
                     </person>
-                    <person xml:id="atys_idas" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Atys_idas</persName>
-                    </person>
-                    <person xml:id="sangaride_doris" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Sangaride_doris</persName>
-                    </person>
-                    <person xml:id="atys_sangaride" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Atys_sangaride</persName>
-                    </person>
                     <person xml:id="les-choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Choeurs</persName>
                     </person>
@@ -114,12 +99,6 @@
                     <person xml:id="melisse" sex="FEMALE">
                         <persName>Mélisse</persName>
                     </person>
-                    <person xml:id="idas_doris" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Idas_doris</persName>
-                    </person>
-                    <person xml:id="atys_idas_doris" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Atys_idas_doris</persName>
-                    </person>
                     <person xml:id="le-sommeil" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Sommeil</persName>
                     </person>
@@ -129,11 +108,8 @@
                     <person xml:id="phobetor" sex="MALE">
                         <persName>Phobetor</persName>
                     </person>
-                    <person xml:id="sommeil_morphee_phobetor_phantase" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Sommeil_morphee_phobetor_phantase</persName>
-                    </person>
-                    <person xml:id="morphee_phobetor_phantase" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Morphee_phobetor_phantase</persName>
+                    <person xml:id="sommeil" sex="UNKNOWN">
+                        <persName>Le Sommeil</persName>
                     </person>
                     <person xml:id="phantase" sex="MALE">
                         <persName>Phantase</persName>
@@ -144,20 +120,11 @@
                     <person xml:id="choeur-des-songes-funestes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Songes Funestes</persName>
                     </person>
-                    <person xml:id="doris_idas" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Doris_idas</persName>
-                    </person>
-                    <person xml:id="sangaride_doris_idas" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Sangaride_doris_idas</persName>
-                    </person>
                     <person xml:id="sangar" sex="MALE">
                         <persName>Le Fleuve Sangar</persName>
                     </person>
                     <person xml:id="fleuves" sex="UNKNOWN">
                         <persName>Dieux de Fleuves</persName>
-                    </person>
-                    <person xml:id="sangar_fleuves" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Sangar_fleuves</persName>
                     </person>
                     <person xml:id="fontaines" sex="UNKNOWN">
                         <persName>Divinités de Fontaines, et de Ruisseaux</persName>
@@ -165,32 +132,20 @@
                     <person xml:id="ruisseaux" sex="UNKNOWN">
                         <persName>Divinités de Ruisseaux</persName>
                     </person>
-                    <person xml:id="fleuve_fontaine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Fleuve_fontaine</persName>
+                    <person xml:id="fleuve" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Fleuve</persName>
                     </person>
-                    <person xml:id="fleuves_fontaines" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Fleuves_fontaines</persName>
+                    <person xml:id="fontaine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Fontaine</persName>
                     </person>
                     <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Choeur</persName>
                     </person>
-                    <person xml:id="sangar_choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Sangar_choeur</persName>
-                    </person>
                     <person xml:id="choeur" sex="UNKNOWN">
                         <persName>Le Choeur</persName>
                     </person>
-                    <person xml:id="cybele_celaenus" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Cybele_celaenus</persName>
-                    </person>
-                    <person xml:id="celaenus_choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Celaenus_choeur</persName>
-                    </person>
-                    <person xml:id="atys_cybele" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Atys_cybele</persName>
-                    </person>
-                    <person xml:id="nymphes_bois" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Nymphes_bois</persName>
+                    <person xml:id="nymphes" sex="UNKNOWN">
+                        <persName>Nymphes</persName>
                     </person>
                     <person xml:id="bois" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Bois</persName>
@@ -200,9 +155,6 @@
                     </person>
                     <person xml:id="corybantes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Corybantes</persName>
-                    </person>
-                    <person xml:id="cybele_choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Cybele_choeurs</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -346,7 +298,7 @@
                         <l n="27">Dans l'ardeur de lui plaire on a bientôt appris</l>
                         <l n="28">À ne rien trouver d'impossible.</l>
                     </sp>
-<sp who="#temps_flore">
+<sp who="#temps #flore">
                         <speaker>LE TEMPS et FLORE.</speaker>
                         <l n="29">Les plaisirs à ses yeux ont beau se présenter,</l>
                         <note type="L">Bellone : Dieu qui personnifie la guerre et accompagne Mars.</note>
@@ -391,7 +343,7 @@
                         <l n="56">Aux ornements des plus beaux arts.</l>
                         <stage type="fly/together">Iris remonte au ciel sur son arc, et la suite de Melpomène s'accorde avec la suite de Flore. </stage>
                     </sp>
-<sp who="#melpomene_flore">
+<sp who="#melpomene #flore">
                         <speaker>MELPOMÈNE et FLORE.</speaker>
                         <l n="57">Rendons-nous, s'il se peut, dignes de ses regards ;</l>
                         <l n="58">Joignons la beauté vive et pure</l>
@@ -577,7 +529,7 @@
                         <l n="156">Mais il faut que chacun s'assemble près de vous,</l>
                         <l n="157">Cybèle pourrait nous surprendre.</l>
                     </sp>
-<sp who="#atys_idas">
+<sp who="#atys #idas">
                         <speaker>ATYS, et IDAS.</speaker>
                         <l n="158">Allons, allons, accourez tous,</l>
                         <l n="159">Cybèle va descendre.</l>
@@ -653,7 +605,7 @@
                         <l n="199">Je prétends être heureuse, au moins, en apparence ;</l>
                         <l n="200">Au destin d'un grand roi je me vais attacher.</l>
                     </sp>
-<sp who="#sangaride_doris">
+<sp who="#sangaride #doris">
                         <speaker>SANGARIDE et DORIS.</speaker>
                         <l n="201">Un amour malheureux dont le devoir s'offense,</l>
                         <l n="202">Se doit condamner au silence ;</l>
@@ -808,7 +760,7 @@
                         <l n="259">Voulez-vous que je vive,</l>
                         <l n="260">Si vous ne vivez pas pour moi ?</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="261">Si l'hymen unissait mon destin et le vôtre,</l>
                         <l n="262">Que ses noeuds auraient eu d'attraits !</l>
@@ -842,7 +794,7 @@
                         <l n="275">Sangaride s'avançant vers la montagne.</l>
                         <l n="276">La déesse descend, allons au devant d'elle.</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="277">Commençons, commençons</l>
                         <l n="278">De célébrer ici sa fête solennelle,</l>
@@ -876,7 +828,7 @@
                         <speaker>LES CHOEURS.</speaker>
                         <l n="290">Venez, favorable Cybèle.</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SDANGARIDE.</speaker>
                         <l n="291">Venez voir les autels qui vous sont destinés.</l>
                     </sp>
@@ -1229,7 +1181,7 @@
                         <speaker>ATYS.</speaker>
                         <l n="476">Vous devez avec moi partager mon bonheur.</l>
                     </sp>
-<sp who="#idas_doris">
+<sp who="#idas #doris">
                         <speaker>IDAS et DORIS.</speaker>
                         <l n="477">Nous venons partager vos mortelles alarmes ;</l>
                         <l n="478">Sangaride les yeux en larmes</l>
@@ -1240,7 +1192,7 @@
                         <l n="480">L'heure approche où l'hymen voudra qu'elle se livre</l>
                         <l n="481">Au pouvoir d'un heureux époux.</l>
                     </sp>
-<sp who="#idas_doris">
+<sp who="#idas #doris">
                         <speaker>IDAS et DORIS.</speaker>
                         <l n="482">Elle ne peut vivre</l>
                         <l n="483">Pour un autre que pour vous.</l>
@@ -1249,7 +1201,7 @@
                         <speaker>ATYS.</speaker>
                         <l n="484">Qui peut la dégager du devoir qui la presse ?</l>
                     </sp>
-<sp who="#idas_doris">
+<sp who="#idas #doris">
                         <speaker>IDAS et DORIS.</speaker>
                         <l n="485">Elle veut elle-même aux pieds de la déesse</l>
                         <l n="486">Déclarer hautement vos secrètes amours.</l>
@@ -1261,7 +1213,7 @@
                         <l n="489">Mais quoi, trahir le roi ! Tromper son espérance !</l>
                         <l n="490">De tant de biens reçus est-ce la récompense ?</l>
                     </sp>
-<sp who="#idas_doris">
+<sp who="#idas #doris">
                         <speaker>IDAS et DORIS.</speaker>
                         <l n="491">Dans l'empire amoureux</l>
                         <l n="492">Le devoir n'a point de puissance ;</l>
@@ -1274,7 +1226,7 @@
                         <speaker>ATYS.</speaker>
                         <l n="497">Je souhaite, je crains, je veux, je me repends.</l>
                     </sp>
-<sp who="#idas_doris">
+<sp who="#idas #doris">
                         <speaker>IDAS et DORIS.</speaker>
                         <l n="498">Verrez-vous un rival heureux à vos dépends ?</l>
                     </sp>
@@ -1282,7 +1234,7 @@
                         <speaker>ATYS.</speaker>
                         <l n="499">Je ne puis me résoudre à cette violence.</l>
                     </sp>
-<sp who="#atys_idas_doris">
+<sp who="#atys #idas #doris">
                         <speaker>ATYS, IDAS et DORIS.</speaker>
                         <l n="500">En vain, un coeur, incertain de son choix.</l>
                         <l n="501">Met en balance mille fois</l>
@@ -1341,7 +1293,7 @@
                         <l n="531">Il n'est permis qu'au bruit des eaux</l>
                         <l n="532">De troubler la douceur d'un si charmant silence.</l>
                     </sp>
-<sp who="#sommeil_morphee_phobetor_phantase">
+<sp who="#sommeil #morphee #phobetor #phantase">
                         <speaker>LE SOMMEIL, MORPHÉE, PHOBETOR, et PHANTASE.</speaker>
                         <l n="533">Dormons, dormons tous,</l>
                         <l n="534">Ah que le repos est doux !</l>
@@ -1353,7 +1305,7 @@
                         <l n="536">Sois sensible à l'honneur d'être aimé de Cybèle,</l>
                         <l n="537">Jouis heureux Atys de ta félicité.</l>
                     </sp>
-<sp who="#morphee_phobetor_phantase">
+<sp who="#morphee #phobetor #phantase">
                         <speaker>MORPHÉE, PHOBETOR et PHANTASE.</speaker>
                         <l n="538">Mais souviens-toi que la beauté,</l>
                         <l n="539">Quand elle est immortelle,</l>
@@ -1382,7 +1334,7 @@
                         <l n="556">Ne vante plus la liberté,</l>
                         <l n="557">Il n'en est point du prix d'une chaîne si belle.</l>
                     </sp>
-<sp who="#morphee_phobetor_phantase">
+<sp who="#morphee #phobetor #phantase">
                         <speaker>MORPHÉE, PHOBETOR et PHANTASE.</speaker>
                         <l n="558">Mais souviens-toi que la beauté,</l>
                         <l n="559">Quand elle est immortelle,</l>
@@ -1645,7 +1597,7 @@
                         <speaker>SANGARIDE.</speaker>
                         <l n="688" part="I">Hélas ! J'aime... Hélas ! J'aime...</l>
                     </sp>
-<sp who="#doris_idas">
+<sp who="#doris #idas">
                         <speaker>DORIS, et IDAS.</speaker>
                         <l n="688" part="M">Achevez.</l>
                     </sp>
@@ -1653,7 +1605,7 @@
                         <speaker>SANGARIDE.</speaker>
                         <l n="688" part="F">Je ne puis.</l>
                     </sp>
-<sp who="#doris_idas">
+<sp who="#doris #idas">
                         <speaker>DORIS, et IDAS.</speaker>
                         <l n="689">L'amour n'est guère heureux lorsqu'il est trop timide.</l>
                     </sp>
@@ -1666,7 +1618,7 @@
                         <l n="694">Hélas ! J'aime un perfide</l>
                         <l n="695">Qui trahit mon amour.</l>
                     </sp>
-<sp who="#doris_idas">
+<sp who="#doris #idas">
                         <speaker>DORIS, et IDAS.</speaker>
                         <l n="696">Il nous montrait tantôt un peu d'incertitude ;</l>
                         <l n="697">Mais qui l'eut soupçonné de tant d'ingratitude ?</l>
@@ -1679,7 +1631,7 @@
                         <l n="701">Mais l'ingrat, l'infidèle,</l>
                         <l n="702">M'empêchât toujours de parler.</l>
                     </sp>
-<sp who="#doris_idas">
+<sp who="#doris #idas">
                         <speaker>DORIS et IDAS.</speaker>
                         <l n="703">Peut-on changer si tôt quand l'amour est extrême ?</l>
                         <l n="704">Gardez-vous, gardez-vous</l>
@@ -1693,7 +1645,7 @@
                         <l n="709">J'accepterai sans peine un glorieux époux,</l>
                         <l n="710">Je ne veux plus aimer que la grandeur suprême.</l>
                     </sp>
-<sp who="#doris_idas">
+<sp who="#doris #idas">
                         <speaker>DORIS et IDAS.</speaker>
                         <l n="711">Peut-on changer si tôt quand l'amour est extrême ?</l>
                         <l n="712">Gardez-vous, gardez-vous</l>
@@ -1710,7 +1662,7 @@
                         <l n="720">Les douceurs d'une heureuse paix ;</l>
                         <l n="721">Revenez, ma raison, revenez pour jamais.</l>
                     </sp>
-<sp who="#doris_idas">
+<sp who="#doris #idas">
                         <speaker>IDAS et DORIS.</speaker>
                         <l n="722">Une infidélité cruelle</l>
                         <l n="723">N'efface point tous les appas</l>
@@ -1725,7 +1677,7 @@
                         <l n="729">Le dépit et la colère</l>
                         <l n="730">Me tiendront lieu de raison.</l>
                     </sp>
-<sp who="#sangaride_doris_idas">
+<sp who="#sangaride #doris #idas">
                         <speaker>SANGARIDE, DORIS, IDAS.</speaker>
                         <l n="731">Qu'une première amour est belle ?</l>
                         <l n="732">Qu'on a peine à s'en dégager !</l>
@@ -1840,7 +1792,7 @@
                         <speaker>ATYS.</speaker>
                         <l n="777" part="F">Quel funeste courroux !</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="778">Pourquoi m'abandonner pour une amour nouvelle ?</l>
                         <l n="779">Ce n'est pas moi qui rompt une chaîne si belle.</l>
@@ -1861,7 +1813,7 @@
                         <speaker>SANGARIDE.</speaker>
                         <l n="783">Ah ! C'est vous amant infidèle.</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="784">Beauté trop cruelle, c'est vous,</l>
                         <l n="785">Amant infidèle, c'est vous,</l>
@@ -1908,7 +1860,7 @@
                         <speaker>SANGARIDE.</speaker>
                         <l n="805" part="F">Je promets,</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="806">De ne changer jamais.</l>
                     </sp>
@@ -1917,7 +1869,7 @@
                         <l n="807">Quel tourment de cacher une si belle flamme.</l>
                         <l n="808">Redoublons-en l'ardeur dans le fonds de nôtre âme.</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="809">Aimons en secret, aimons-nous :</l>
                         <l n="810">Aimons plus que jamais, en dépit des jaloux.</l>
@@ -1969,7 +1921,7 @@
                         <l n="834">On a beau chasser le chagrin,</l>
                         <l n="835">Il revient plutôt qu'on ne pense.</l>
                     </sp>
-<sp who="#sangar_fleuves">
+<sp who="#sangar #fleuves">
                         <speaker>LE DIEU DU FLEUVE SANGAR, et LE CHOEUR.</speaker>
                         <l n="836">Que l'on chante, que l'on danse,</l>
                         <l n="837">Rions tous lorsqu'il le faut ;</l>
@@ -2017,7 +1969,7 @@
                         <l n="876">L'hymen vient quand on l'appelle,</l>
                         <l n="877">L'amour vient quand il lui plaît.</l>
                     </sp>
-<sp who="#fleuve_fontaine">
+<sp who="#fleuve #fontaine">
                         <speaker>Un DIEU DE FLEUVE et une DIVINITÉ DE FONTAINE et chantent ensemble.</speaker>
                         <l n="878">D'une constance extrême,</l>
                         <l n="879">Un ruisseau suit son cours ;</l>
@@ -2032,7 +1984,7 @@
                         <l n="888">Il cherche encor l'orage</l>
                         <l n="889">Au moment qu'il en sort.</l>
                     </sp>
-<sp who="#fleuves_fontaines">
+<sp who="#fleuves #fontaines">
                         <speaker>CHOEUR DE DIEUX de FLEUVES, et de DIVINITÉS de FONTAINES.</speaker>
                         <l n="890">Un grand calme est trop fâcheux,</l>
                         <l n="891">Nous aimons mieux la tourmente.</l>
@@ -2045,7 +1997,7 @@
 </div>
 <div type="scene" n="6">
                     <head>SCÈNE VI. Atys, troupe de zéphyrs volants, Sangaride, Celaenus, le dieu du fleuve Sangar, troupe de dieux de fleuves, de ruisseaux, et de divinités de fontaines.</head>
-<sp who="#fleuves_fontaines">
+<sp who="#fleuves #fontaines">
                         <speaker>CHOEUR de DIEUX DE FLEUVES, et de FONTAINES.</speaker>
                         <l n="897">Venez former des noeuds charmants,</l>
                         <l n="898">Atys, venez unir ces bienheureux amants.</l>
@@ -2071,7 +2023,7 @@
                         <l n="906">Seigneur, je suis à la déesse,</l>
                         <l n="907">Dés qu'elle a commandé, je ne puis qu'obéir</l>
                     </sp>
-<sp who="#sangar_choeur">
+<sp who="#sangar #choeur">
                         <speaker>LE DIEU DU FLEUVE SANGAR, et LE CHOEUR.</speaker>
                         <l n="908">Pourquoi faut-il qu'elle sépare</l>
                         <l n="909">Deux illustres amants pour qui l'hymen prépare</l>
@@ -2166,40 +2118,40 @@
 </div>
 <div type="scene" n="2">
                     <head>SCÈNE II. Atys, Sangaride, Cybèle, Celaenus, Mélisse, troupe de prêtresses de Cybèle.</head>
-<sp who="#cybele_celaenus">
+<sp who="#cybele #celaenus">
                         <speaker>CYBÈLE et CELAENUS.</speaker>
                         <l n="956">Venez vous livrer au supplice.</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="957">Quoi la terre et le ciel contre nous sont armés ?</l>
                         <l n="958">Souffrirez-vous qu'on nous punisse ?</l>
                     </sp>
-<sp who="#cybele_celaenus">
+<sp who="#cybele #celaenus">
                         <speaker>CYBÈLE et CELAENUS.</speaker>
                         <l n="959">Oubliez-vous votre injustice ?</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="960">Ne vous souvient-il plus de nous avoir aimés ?</l>
                     </sp>
-<sp who="#cybele_celaenus">
+<sp who="#cybele #celaenus">
                         <speaker>CYBÈLE et CELAENUS.</speaker>
                         <l n="961">Vous changez mon amour en haine légitime.</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="962">Pouvez-vous condamner</l>
                         <l n="963">L'amour qui nous anime ?</l>
                         <l n="964">Si c'est un crime,</l>
                         <l n="965">Quel crime est plus à pardonner ?</l>
                     </sp>
-<sp who="#cybele_celaenus">
+<sp who="#cybele #celaenus">
                         <speaker>CYBÈLE et CELAENUS.</speaker>
                         <l n="966">Perfide, deviez-vous me taire</l>
                         <l n="967">Que c'était vainement que je voulais vous plaire ?</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="968">Ne pouvant suivre vos désirs,</l>
                         <l n="969">Nous croyons ne pouvoir mieux faire</l>
@@ -2209,33 +2161,33 @@
                         <speaker>CYBÈLE.</speaker>
                         <l n="971">D'un supplice cruel craignez l'horreur extrême.</l>
                     </sp>
-<sp who="#cybele_celaenus">
+<sp who="#cybele #celaenus">
                         <speaker>CYBÈLE et CELAENUS.</speaker>
                         <l n="972">Craignez un funeste trépas.</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="973">Vengez-vous, s'il le faut, ne me pardonnez pas,</l>
                         <l n="974">Mais pardonnez à ce que j'aime.</l>
                     </sp>
-<sp who="#cybele_celaenus">
+<sp who="#cybele #celaenus">
                         <speaker>CYBÈLE et CELAENUS.</speaker>
                         <l n="975">C'est peu de nous trahir, vous nous bravez, ingrats ?</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="976">Serez-vous sans pitié ?</l>
                     </sp>
-<sp who="#cybele_celaenus">
+<sp who="#cybele #celaenus">
                         <speaker>CYBÈLE et CELAENUS.</speaker>
                         <l n="977">Perdez toute espérance.</l>
                     </sp>
-<sp who="#atys_sangaride">
+<sp who="#atys #sangaride">
                         <speaker>ATYS et SANGARIDE.</speaker>
                         <l n="978">L'amour nous a forcés à vous faire une offense,</l>
                         <l n="979">Il demande grâce pour nous.</l>
                     </sp>
-<sp who="#cybele_celaenus">
+<sp who="#cybele #celaenus">
                         <speaker>CYBÈLE et CELAENUS.</speaker>
                         <l n="980">L'amour en courroux</l>
                         <l n="981">Demande vengeance.</l>
@@ -2290,7 +2242,7 @@
                         <l n="1003">Il faut combattre ; amour, seconde mon courage.</l>
                         <stage type="run/follow/location">Atys court après Sangaride qui fuit dans un des côtés du théâtre.</stage>
                     </sp>
-<sp who="#celaenus_choeur">
+<sp who="#celaenus #choeur">
                         <speaker>CELAENUS, et LE CHOEUR.</speaker>
                         <l n="1004">Arrête, arrête malheureux.</l>
                         <stage type="run/follow">Celaenus court après Atys.</stage>
@@ -2467,7 +2419,7 @@
                         <l n="1087">Plaignez-vous, je veux tout souffrir.</l>
                         <l n="1088">Pourquoi suis-je immortelle en vous voyant périr ?</l>
                     </sp>
-<sp who="#atys_cybele">
+<sp who="#atys #cybele">
                         <speaker>ATYS et CYBÈLE.</speaker>
                         <l n="1089">Il est doux de mourir</l>
                         <l n="1090">Avec ce que l'on aime.</l>
@@ -2526,7 +2478,7 @@
                         <l n="1123">Célébrez son nouveau destin,</l>
                         <l n="1124">Pleurez sa funeste aventure.</l>
                     </sp>
-<sp who="#nymphes_bois">
+<sp who="#nymphes #bois">
                         <speaker>CHOEUR des NYMPHES des EAUX, et des DIVINITES des BOIS.</speaker>
                         <l n="1125">Célébrons son nouveau destin,</l>
                         <l n="1126">Pleurons sa funeste aventure.</l>
@@ -2562,7 +2514,7 @@
                         <speaker>CYBÈLE, et le choeur des corybantes.</speaker>
                         <l n="1143">Ah ! Quelle rage !</l>
                     </sp>
-<sp who="#cybele_choeurs">
+<sp who="#cybele #choeurs">
                         <speaker>CYBÈLE, et les choeurs.</speaker>
                         <l n="1144">Ah ! Quel malheur !</l>
                     </sp>

--- a/tei/quinault-cadmus-hermione.xml
+++ b/tei/quinault-cadmus-hermione.xml
@@ -65,9 +65,6 @@
                     <person xml:id="le-soleil" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Soleil</persName>
                     </person>
-                    <person xml:id="pales_melisse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Pales_melisse</persName>
-                    </person>
                     <person xml:id="archas" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Archas</persName>
                     </person>
@@ -115,12 +112,6 @@
                     </person>
                     <person xml:id="pallas" sex="FEMALE">
                         <persName>Pallas</persName>
-                    </person>
-                    <person xml:id="charite_arbas" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Charite_arbas</persName>
-                    </person>
-                    <person xml:id="hermione_cadmus" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Hermione_cadmus</persName>
                     </person>
                     <person xml:id="l-amour" sex="MALE">
                         <persName>L'Amour</persName>
@@ -529,7 +520,7 @@
                         <speaker>LE CHOEUR.</speaker>
                         <l n="96">Profitons des beaux jours.</l>
                     </sp>
-<sp who="#pales_melisse">
+<sp who="#pales #melisse">
                         <speaker>PALÈS et MÉLISSE.</speaker>
                         <l n="97">Les plus beaux jours de la vie</l>
                         <l n="98">Sont perdus sans les Amours.</l>
@@ -1103,7 +1094,7 @@
                         <l n="392">C'est par un dépit heureux</l>
                         <l n="393">Qu'il faut se tirer d'affaire.</l>
                     </sp>
-<sp who="#charite_arbas">
+<sp who="#charite #arbas">
                         <speaker>CHARITE et ARBAS ensemble.</speaker>
                         <l n="394">Quand on désespère</l>
                         <l n="395">Un coeur amoureux ;</l>
@@ -1305,7 +1296,7 @@
                         <l n="485">L'Amour que j'ai pour vous ne croit rien d'impossible :</l>
                         <l n="486">Il me flatte en partant d'un bienheureux retour.</l>
                     </sp>
-<sp who="#hermione_cadmus">
+<sp who="#hermione #cadmus">
                         <speaker>HERMIONE et CADMUS, ensemble.</speaker>
                         <l n="487">Croyez en mon amour,</l>
                     </sp>
@@ -1318,7 +1309,7 @@
                         <speaker>CADMUS.</speaker>
                         <l n="489" part="F">Le temps presse.</l>
                     </sp>
-<sp who="#hermione_cadmus">
+<sp who="#hermione #cadmus">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="490">Au nom des plus beaux noeuds que l'Amour ait formés,</l>
                         <l n="491">Vivez, si vous m'aimez.</l>
@@ -1332,7 +1323,7 @@
                         <l n="492" part="F">Tout me désespère.</l>
                         <l n="493">Que je me veux de mal d'avoir trop sçû vous plaire !</l>
                     </sp>
-<sp who="#hermione_cadmus">
+<sp who="#hermione #cadmus">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="494">Qu'un tendre amour coûte d'ennuis !</l>
                     </sp>
@@ -1362,7 +1353,7 @@
                         <speaker>CADMUS.</speaker>
                         <l n="498" part="M">Hermione !</l>
                     </sp>
-<sp who="#hermione_cadmus">
+<sp who="#hermione #cadmus">
                         <speaker>HERMIONE et CADMUS, ensemble.</speaker>
                         <l n="498" part="F">Adieu.</l>
                     </sp>

--- a/tei/quinault-comedie-sans-comedie.xml
+++ b/tei/quinault-comedie-sans-comedie.xml
@@ -134,8 +134,11 @@
                     <person xml:id="agis" sex="MALE">
                         <persName>Agis</persName>
                     </person>
-                    <person xml:id="un-triton-et-une-sirene" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Un Triton et une Sirene</persName>
+                    <person xml:id="un-triton" sex="MALE">
+                        <persName>Un Triton</persName>
+                    </person>
+                    <person xml:id="une-sirene" sex="MALE">
+                        <persName>Une Sirène</persName>
                     </person>
                     <person xml:id="l-amour" sex="MALE">
                         <persName>L'Amour</persName>
@@ -4153,7 +4156,7 @@ Larve : Génie malfaisant, qu'on croyait errer sous des formes hideuses. [L]</no
 </div>
 <div type="scene" n="5">
                     <head>SCÈNE V. Un Triton, une Sirène, Renaud.</head>
-<sp who="#un-triton-et-une-sirene">
+<sp who="#un-triton #une-sirene">
                         <speaker>UN TRITON et UNE SIRENE chantent.</speaker>
                         <ab type="chanson"><!--<poem>-->
 <lg n="1">
@@ -4172,7 +4175,7 @@ Larve : Génie malfaisant, qu'on croyait errer sous des formes hideuses. [L]</no
                         <l n="1574">Sont contraints de céder au sommeil qui m'accable.</l>
                         <stage type="sleep/sing">Renaud s'endort et le Triton et la Sirène continuent à chanter.</stage>
                     </sp>
-<sp who="#un-triton-et-une-sirene">
+<sp who="#un-triton #une-sirene">
                         <speaker>UN TRITON et UNE SIRENE chantent.</speaker>
                         <ab type="chanson"><!--<poem>-->
 <lg n="1">

--- a/tei/quinault-fetes-amour-bacchus.xml
+++ b/tei/quinault-fetes-amour-bacchus.xml
@@ -74,8 +74,11 @@
                     <person xml:id="vieille-bourgeois-babillarde" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Vieille Bourgeois Babillarde</persName>
                     </person>
-                    <person xml:id="hommes-et-femmes-du-bel-air" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Hommes et Femmes du Bel Air</persName>
+                    <person xml:id="hommes-du-bel-air" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Hommes du Bel Air</persName>
+                    </person>
+                    <person xml:id="femmes-du-bel-air" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Femmes du Bel Air</persName>
                     </person>
                     <person xml:id="tous-ensemble" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous Ensemble</persName>
@@ -88,9 +91,6 @@
                     </person>
                     <person xml:id="euterpe" sex="FEMALE">
                         <persName>Euterpe</persName>
-                    </person>
-                    <person xml:id="melpomene-et-euterpe" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Melpomene et Euterpe</persName>
                     </person>
                     <person xml:id="les-trois-muses" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Trois Muses</persName>
@@ -361,7 +361,7 @@
                         <l n="59">Un vrai cheval</l>
                         <l n="60">Franc animal.</l>
                     </sp>
-<sp who="#hommes-et-femmes-du-bel-air">
+<sp who="#hommes-du-bel-air #femmes-du-bel-air">
                         <speaker>HOMMES ET FEMMES DU BEL AIR.</speaker>
                         <l n="61">Ah quel bruit ! </l>
                         <l n="62">Quel fracas !</l>
@@ -482,7 +482,7 @@
                         <l n="130">Qui méritât jamais de tenir sous sa loi</l>
                         <l n="131">Tout ce que le Soleil éclaire.</l>
                     </sp>
-<sp who="#melpomene-et-euterpe">
+<sp who="#melpomene #euterpe">
                         <speaker>MELPOMÈNE et EUTERPE.</speaker>
                         <l n="132">C'est à moi, c'est à moi,</l>
                         <l n="133">De prétendre à lui plaire,</l>

--- a/tei/quinault-grotte.xml
+++ b/tei/quinault-grotte.xml
@@ -58,17 +58,14 @@
                     <person xml:id="caliste" sex="FEMALE">
                         <persName>Caliste</persName>
                     </person>
-                    <person xml:id="lycas-et-le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Lycas et le Choeur</persName>
+                    <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Le Choeur</persName>
                     </person>
                     <person xml:id="menalque" sex="MALE">
                         <persName>Ménalque</persName>
                     </person>
                     <person xml:id="daphnis" sex="MALE">
                         <persName>Daphnis</persName>
-                    </person>
-                    <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Choeur</persName>
                     </person>
                     <person xml:id="l-echo" sex="FEMALE">
                         <persName>Caliste</persName>
@@ -191,7 +188,7 @@
                         <l n="27">Elle ne se peut faire </l>
                         <l n="28">Qu'au printemps de nos jours. </l>
                     </sp>
-<sp who="#lycas-et-le-choeur">
+<sp who="#lycas #le-choeur">
                         <speaker>LYCAS ET LE CHOEUR des Bergers répètent le Récit précédent. </speaker>
                         <l n="29">Dans ces charmantes Retraites.</l>
                     </sp>

--- a/tei/quinault-isis.xml
+++ b/tei/quinault-isis.xml
@@ -59,9 +59,6 @@
                     <person xml:id="neptune" sex="MALE">
                         <persName>Neptune</persName>
                     </person>
-                    <person xml:id="la-renommee_neptune" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Renommee_neptune</persName>
-                    </person>
                     <person xml:id="choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeurs</persName>
                     </person>
@@ -86,9 +83,6 @@
                     <person xml:id="io" sex="FEMALE">
                         <persName>Io</persName>
                     </person>
-                    <person xml:id="hierax_io" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Hierax_io</persName>
-                    </person>
                     <person xml:id="micene" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Micene</persName>
                     </person>
@@ -107,14 +101,8 @@
                     <person xml:id="iris" sex="FEMALE">
                         <persName>Iris</persName>
                     </person>
-                    <person xml:id="mercure_iris" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Mercure_iris</persName>
-                    </person>
                     <person xml:id="junon" sex="FEMALE">
                         <persName>Junon</persName>
-                    </person>
-                    <person xml:id="iris_mercure" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Iris_mercure</persName>
                     </person>
                     <person xml:id="hebe" sex="FEMALE">
                         <persName>Hébé</persName>
@@ -125,17 +113,11 @@
                     <person xml:id="argus" sex="MALE">
                         <persName>Argus</persName>
                     </person>
-                    <person xml:id="hierax_argus" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Hierax_argus</persName>
-                    </person>
                     <person xml:id="syrinx" sex="FEMALE">
                         <persName>Une Nymphe</persName>
                     </person>
                     <person xml:id="choeur-des-nymphes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Nymphes</persName>
-                    </person>
-                    <person xml:id="syrinx_choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Syrinx_choeurs</persName>
                     </person>
                     <person xml:id="choeurs-de-nymphes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeurs de Nymphes</persName>
@@ -167,9 +149,6 @@
                     <person xml:id="troupe-de-sylvains-et-de-satyres" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Troupe de Sylvains et de Satyres</persName>
                     </person>
-                    <person xml:id="pan_deux-bergers" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Pan_deux Bergers</persName>
-                    </person>
                     <person xml:id="choeur-des-peuples" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Peuples</persName>
                     </person>
@@ -194,8 +173,11 @@
                     <person xml:id="le-choeur-des-chalybes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Choeur des Chalybes</persName>
                     </person>
-                    <person xml:id="conducteurs_choeurs-chalybes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Conducteurs_choeurs Chalybes</persName>
+                    <person xml:id="conducteurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Conducteurs</persName>
+                    </person>
+                    <person xml:id="choeurs-chalybes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Choeurs Chalybes</persName>
                     </person>
                     <person xml:id="choeur-chalybes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur Chalybes</persName>
@@ -242,17 +224,14 @@
                     <person xml:id="furie" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Furie</persName>
                     </person>
-                    <person xml:id="choeur_divinites" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Choeur_divinites</persName>
+                    <person xml:id="divinites" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Divinites</persName>
                     </person>
                     <person xml:id="peuples" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Peuples</persName>
                     </person>
                     <person xml:id="egypte" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Egypte</persName>
-                    </person>
-                    <person xml:id="jupiter_junon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Jupiter_junon</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -471,7 +450,7 @@
                         <l n="32">Si fameux sur la terre</l>
                         <l n="33">Qui triomphe encor sur les eaux.</l>
                     </sp>
-<sp who="#la-renommee_neptune">
+<sp who="#la-renommee #neptune">
                         <speaker>LA RENOMMÉE et NEPTUNE.</speaker>
                         <l n="34">Célébrez son grand nom sur la terre et sur l'onde</l>
                         <l n="35">Qu'il ne soit pas borné par les plus vastes mers</l>
@@ -739,7 +718,7 @@ les Arts libéraux.</head>
                         <l n="186">Autant que je le dois,</l>
                         <l n="187">Et vous me forcez à vous craindre.</l>
                     </sp>
-<sp who="#hierax_io">
+<sp who="#hierax #io">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="188">Non, non, il ne tient qu'à vous</l>
                         <l n="189">De rendre notre sort plus doux</l>
@@ -1101,7 +1080,7 @@ les Arts libéraux.</head>
                         <l n="373">Je vous permets d'être inconstant,</l>
                         <l n="374">Sitôt que je serai volage.</l>
                     </sp>
-<sp who="#mercure_iris">
+<sp who="#mercure #iris">
                         <speaker>MERCURE et IRIS, ensemble.</speaker>
                         <l n="375">Promettez moi de constantes amours,</l>
                         <l n="376">Je vous promets de vous aimer toujours.</l>
@@ -1114,7 +1093,7 @@ les Arts libéraux.</head>
                         <speaker>IRIS.</speaker>
                         <l n="378">Parlons sans mystère en ce jour;</l>
                     </sp>
-<sp who="#mercure_iris">
+<sp who="#mercure #iris">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="379">Le moindre artifice</l>
                         <l n="380">Offense l'amour.</l>
@@ -1145,7 +1124,7 @@ les Arts libéraux.</head>
                         <l n="390">Vous ne l'êtes pas plus que moi.</l>
                         <stage type="entrance/location/decor">Junon paraît au milieu d'un nuage qui s'avance.</stage>
                     </sp>
-<sp who="#mercure_iris">
+<sp who="#mercure #iris">
                         <speaker>MERCURE et IRIS.</speaker>
                         <l n="391">Gardez pour quelque autre</l>
                         <l n="392">Votre amour trompeur,</l>
@@ -1236,7 +1215,7 @@ les Arts libéraux.</head>
                         <l n="443">Et portez à son gré, mes ordres en tous lieux;</l>
                         <l n="444">Que tout suive les lois de la reine des cieux.</l>
                     </sp>
-<sp who="#iris_mercure">
+<sp who="#iris #mercure">
                         <speaker>IRIS et MERCURE.</speaker>
                         <l n="445">Que tout suive les lois de la reine des Cieux.</l>
                     </sp>
@@ -1487,7 +1466,7 @@ les Arts libéraux.</head>
                         <l n="569">Un coeur ingrat vaut-il la peine</l>
                         <l n="570">D'être tant regretté.</l>
                     </sp>
-<sp who="#hierax_argus">
+<sp who="#hierax #argus">
                         <speaker>HIÉRAX et ARGUS.</speaker>
                         <l n="571">Heureux qui peut briser</l>
                         <l n="572">Qui peut briser sa chaîne</l>
@@ -1514,7 +1493,7 @@ habits de chasse.</head>
                         <l n="576">S'il est quelque bien au monde</l>
                         <l n="577">C'est la liberté.</l>
                     </sp>
-<sp who="#hierax_argus">
+<sp who="#hierax #argus">
                         <speaker>HIÉRAX et ARGUS.</speaker>
                         <l n="578">Que voulez-vous ?</l>
                     </sp>
@@ -1522,11 +1501,11 @@ habits de chasse.</head>
                         <speaker>CHOEUR des NYMPHES.</speaker>
                         <l n="579">Liberté, liberté.</l>
                     </sp>
-<sp who="#hierax_argus">
+<sp who="#hierax #argus">
                         <speaker>HIÉRAX et ARGUS.</speaker>
                         <l n="580">Que voulez-vous ? il faut qu'on nous réponde.</l>
                     </sp>
-<sp who="#syrinx_choeurs">
+<sp who="#syrinx #choeurs">
                         <speaker>SYRINX et les NYMPHES.</speaker>
                         <l n="581">S'il est quelque bien au monde,</l>
                         <l n="582">C'est la liberté.</l>
@@ -1767,7 +1746,7 @@ l'Amour.</stage>
                         <speaker>SYRINX.</speaker>
                         <l n="700" part="F">Un amant m'embarrasse.</l>
                     </sp>
-<sp who="#syrinx_choeurs">
+<sp who="#syrinx #choeurs">
                         <speaker>SYRINX et les CHOEURS derrière le théâtre.</speaker>
                         <l n="701">Courons à la chasse, à la chasse.</l>
                     </sp>
@@ -1838,7 +1817,7 @@ l'Amour.</stage>
                         <l n="731">Brûler avec le mien d'une ardeur éternelle ?</l>
                         <l n="732">Que tout ressente mes tourments.</l>
                     </sp>
-<sp who="#pan_deux-bergers">
+<sp who="#pan #deux-bergers">
                         <speaker>PAN, et deux BERGERS accompagnés du concert de flutes.</speaker>
                         <l n="733">Ranimons les restes charmants</l>
                         <l n="734">D'un nymphe qui fut si belle,</l>
@@ -1881,7 +1860,7 @@ l'Amour.</stage>
                         <l n="748">Pour un malheureux comme moi.</l>
                         <l n="749">Éveillez vous, Argus, éveillez-vous, vous vous laissez surprendre.</l>
                     </sp>
-<sp who="#hierax_argus">
+<sp who="#hierax #argus">
                         <speaker>HIÉRAX et ARGUS.</speaker>
                         <l n="750">Puissante reine des cieux </l>
                         <l n="751">Junon venez nous défendre.</l>
@@ -2076,7 +2055,7 @@ l'Amour.</stage>
                         <l n="828">Que vous haïssez fortement,</l>
                         <l n="829">Grand Dieux ! Qu'il s'en faut bien que vous aimiez de même !</l>
                     </sp>
-<sp who="#conducteurs_choeurs-chalybes">
+<sp who="#conducteurs #choeurs-chalybes">
                         <speaker>Les CONDUCTEURS et le CHOEUR des CHALYBES.</speaker>
                         <l n="830">Qu'on prépare tout ce qu'il faut </l>
                         <l n="831">Tôt, tôt, tôt, tôt, tôt.</l>
@@ -2415,7 +2394,7 @@ l'Amour.</stage>
                         <stage type="down/decor">Les divinités du Ciel descendent pour recevoir Isis; les peuples d'Egypte lui dressent un autel et la reconnaissent pour la Divinité qui les doit protéger.</stage>
                         <stage type="fly/down">Divinités qui descendent du Ciel dans la gloire, Peuples d'Egypte chantants, quatre égyptiens chantants, peuples d'Egypte dansants.</stage>
                     </sp>
-<sp who="#choeur_divinites">
+<sp who="#choeur #divinites">
                         <speaker>CHOEUR des DIVINITÉS.</speaker>
                         <l n="975">Venez, venez, Divinités nouvelle,</l>
                     </sp>
@@ -2424,12 +2403,12 @@ l'Amour.</stage>
                         <l n="976">Isis, Tournez sur nous vos yeux</l>
                         <l n="977">Voyez l'ardeur de notre zèle.</l>
                     </sp>
-<sp who="#choeur_divinites">
+<sp who="#choeur #divinites">
                         <speaker>CHOEUR des DIVINITÉS.</speaker>
                         <l n="978">La céleste Cour vous appelle</l>
                     </sp>
 <stage type="closer/location">Jupiter et Junon prennent place au milieu des divinités, et y font placer Isis.</stage>
-<sp who="#jupiter_junon">
+<sp who="#jupiter #junon">
                         <speaker>JUPITER et JUNON.</speaker>
                         <l n="979">Isis est immortelle</l>
                         <l n="980">Isis va briller dans les Cieux.</l>

--- a/tei/quinault-mere-coquette.xml
+++ b/tei/quinault-mere-coquette.xml
@@ -53,7 +53,7 @@
                     <person xml:id="acante" sex="MALE">
                         <persName>Acante</persName>
                     </person>
-                    <person xml:id="le-marquis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                    <person xml:id="le-marquis" sex="MALE">
                         <persName>Le Marquis</persName>
                     </person>
                     <person xml:id="cremante" sex="MALE">
@@ -141,7 +141,7 @@
 			<castItem>
                     <role corresp="#acante">ACANTE</role>, amant d'Isabelle.</castItem>
 			<castItem>
-                    <role corresp="#le_marquis">LE MARQUIS</role>, cousin d'Acante.</castItem>
+                    <role corresp="#le-marquis">LE MARQUIS</role>, cousin d'Acante.</castItem>
 			<castItem>
                     <role corresp="#cremante">CRÉMANTE</role>, père d'Acante.</castItem>
 			<castItem>

--- a/tei/quinault-proserpine.xml
+++ b/tei/quinault-proserpine.xml
@@ -49,23 +49,23 @@
                     <person xml:id="la-discorde" sex="FEMALE">
                         <persName>La Discorde</persName>
                     </person>
-                    <person xml:id="la-paix_sa-suite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Paix_sa Suite</persName>
+                    <person xml:id="suite-de-la-paix" sex="UNKNOWN">
+                        <persName>Suite de la Paix</persName>
                     </person>
-                    <person xml:id="la-discorde_sa-suite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Discorde_sa Suite</persName>
+                    <person xml:id="suite-de-la-discorde" sex="UNKNOWN">
+                        <persName>Suite de la Discorde</persName>
                     </person>
                     <person xml:id="la-victoire" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>La Victoire</persName>
                     </person>
-                    <person xml:id="sa-suite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Sa Suite</persName>
-                    </person>
-                    <person xml:id="la-felicite_l-abondance" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>La Felicite_l Abondance</persName>
+                    <person xml:id="suite-de-la-victoire" sex="UNKNOWN">
+                        <persName>Suite de la Victoire</persName>
                     </person>
                     <person xml:id="la-felicite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>La Felicite</persName>
+                    </person>
+                    <person xml:id="l-abondance" sex="FEMALE">
+                        <persName>L'Abondance</persName>
                     </person>
                     <person xml:id="le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Choeur</persName>
@@ -91,14 +91,8 @@
                     <person xml:id="proserpine" sex="FEMALE">
                         <persName>Proserpine</persName>
                     </person>
-                    <person xml:id="proserpine_le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Proserpine_le Choeur</persName>
-                    </person>
                     <person xml:id="ascalaphe" sex="MALE">
                         <persName>Ascalaphe</persName>
-                    </person>
-                    <person xml:id="arethuse_alphee" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Arethuse_alphee</persName>
                     </person>
                     <person xml:id="pluton" sex="MALE">
                         <persName>Pluton</persName>
@@ -106,26 +100,17 @@
                     <person xml:id="pluton-ascalaphe" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Pluton Ascalaphe</persName>
                     </person>
-                    <person xml:id="proserpine_ses-nymphes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Proserpine_ses Nymphes</persName>
-                    </person>
-                    <person xml:id="choeur-de-nymphes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Choeur de Nymphes</persName>
+                    <person xml:id="nymphes" sex="UNKNOWN">
+                        <persName>Troupe de Nymphes</persName>
                     </person>
                     <person xml:id="divinites-infernales" sex="UNKNOWN">
                         <persName>Troupe de Divinités Infernales</persName>
-                    </person>
-                    <person xml:id="pluton_ascalaphe_divinites-infernales" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Pluton_ascalaphe_divinites Infernales</persName>
                     </person>
                     <person xml:id="tous-ensemble" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous Ensemble</persName>
                     </person>
                     <person xml:id="deux-nymphes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Deux Nymphes</persName>
-                    </person>
-                    <person xml:id="ceres_le-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Ceres_le Choeur</persName>
                     </person>
                     <person xml:id="le-choeur-des-ombres" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Choeur des Ombres</persName>
@@ -228,7 +213,7 @@
 			<castItem>
                     <role corresp="#la-discorde">LA DISCORDE</role>.</castItem>
 			<castItem>
-                    <role corresp="#la-suite-de-la-discorde">Suite de la Discorde</role>.</castItem>
+                    <role corresp="#suite-de-la-discorde">Suite de la Discorde</role>.</castItem>
 			<castItem>
                     <role corresp="#la-jalousie">LA JALOUSIE</role>.</castItem>
 			<castItem>
@@ -273,7 +258,7 @@
 			<castItem>
                     <role corresp="#dieux-des-bois">Troupe de dieux des bois</role>.</castItem>
 			<castItem>
-                    <role corresp="#habitants_sicile">Troupe d'habitants de Sicile</role>.</castItem>
+                    <role corresp="#habitants-sicile">Troupe d'habitants de Sicile</role>.</castItem>
 			<castItem>
                     <role corresp="#pluton">PLUTON</role>, dieu des Enfers.</castItem>
 			<castItem>
@@ -353,23 +338,23 @@
                         <l n="22">Il oublie aisément pour elle</l>
                         <l n="23">La paix et ses plus doux appas.</l>
                     </sp>
-<sp who="#la-paix_sa-suite">
+<sp who="#la-paix #suite-de-la-paix">
                         <speaker>LA PAIX et sa suite.</speaker>
                         <l n="24">Ô rigueurs inhumaines !</l>
                         <l n="25">Faut-il ne voir jamais finir le triste cours</l>
                         <l n="26">De nos malheurs, et de nos peines ?</l>
                     </sp>
-<sp who="#la-discorde_sa-suite">
+<sp who="#la-discorde #suite-de-la-discorde">
                         <speaker>LA DISCORDE et sa suite.</speaker>
                         <l n="27">Vos plaintes seront vaines</l>
                         <l n="28">N'espérez jamais de secours.</l>
                     </sp>
-<sp who="#la-paix_sa-suite">
+<sp who="#la-paix #suite-de-la-paix">
                         <speaker>LA PAIX et sa suite.</speaker>
                         <l n="29">Quel tourment de languir toujours</l>
                         <l n="30">Sous de cruelles chaînes !</l>
                     </sp>
-<sp who="#la-discorde_sa-suite">
+<sp who="#la-discorde #suite-de-la-discorde">
                         <speaker>LA DISCORDE et sa suite.</speaker>
                         <l n="31">Vos plaintes seront vaines</l>
                         <l n="32">N'espérez jamais de secours.</l>
@@ -391,16 +376,16 @@
                         <l n="40">Vous, discorde affreuse et cruelle,</l>
                         <l n="41">Portez ses fers à votre tour.</l>
                     </sp>
-<sp who="#la-victoire #sa-suite">
+<sp who="#la-victoire #suite-de-la-victoire">
                         <speaker>LA VICTOIRE et sa suite.</speaker>
                         <l n="42">Venez, aimable paix, le vainqueur vous appelle.</l>
                         <stage type="narration">La suite de la Victoire déchaîne la Paix et les divinités qui l'accompagnent, et enchaîne la Discorde et sa suite.</stage>
                     </sp>
-<sp who="#la-paix #sa-suite">
+<sp who="#la-paix #suite-de-la-paix">
                         <speaker>LA PAIX et sa suite.</speaker>
                         <l n="43">Ah ! Quel bonheur charmant !</l>
                     </sp>
-<sp who="#la-discorde #sa-suite">
+<sp who="#la-discorde #suite-de-la-discorde">
                         <speaker>LA DISCORDE et sa suite.</speaker>
                         <l n="44">Ah ! Quel affreux tourment !</l>
                     </sp>
@@ -451,11 +436,11 @@
                         <l n="70">Le pouvoir plein d'appas de la Paix triomphante.</l>
                         <stage type="fall/decor">La Discorde et sa suite s'abîment dans des gouffres qui s'ouvrent sous leurs pas, et l'affreuse retraite de la Discorde se change en un palais agréable.</stage>
                     </sp>
-<sp who="#la-paix #sa-suite">
+<sp who="#la-paix #suite-de-la-paix">
                         <speaker>LA PAIX et sa suite.</speaker>
                         <l n="71">Ah quel bonheur charmant !</l>
                     </sp>
-<sp who="#la-discorde #sa-suite">
+<sp who="#la-discorde #suite-de-la-discorde">
                         <speaker>LA DISCORDE et sa suite en s'abîmant.</speaker>
                         <l n="72">Ah ! Quel affreux tourment !</l>
                     </sp>
@@ -467,7 +452,7 @@
                         <l n="76">Pour faire triompher la paix.</l>
                         <stage type="repeat">La suite de la victoire et la suite de la paix répètent ces quatre vers. La suite de la paix témoigne sa joie en dansant et en chantant.</stage>
                     </sp>
-<sp who="#la-felicite_l-abondance">
+<sp who="#la-felicite #l-abondance">
                         <speaker>LA FÉLICITÉ et L'ABONDANCE chantent ensemble.</speaker>
                         <l n="77">Il est temps que l'amour nous enchaîne,</l>
                         <l n="78">Il sait vaincre les plus fiers vainqueurs.</l>
@@ -867,7 +852,7 @@
 </div>
 <div type="scene" n="8">
                     <head>SCÈNE VIII. Proserpine, Alphée, Arethuse, Cyané, Crinise, troupe de divinités, troupe de peuples.</head>
-<sp who="#proserpine_le-choeur">
+<sp who="#proserpine #le-choeur">
                         <speaker>PROSERPINE et LE CHOEUR.</speaker>
                         <l n="311">Célébrons la victoire</l>
                         <l n="312">Du plus puissant des dieux.</l>
@@ -1090,7 +1075,7 @@
                         <l n="432">Si je disais que je vous aime,</l>
                         <l n="433">Vous m'ôteriez encor le plaisir de vous voir.</l>
                     </sp>
-<sp who="#arethuse_alphee">
+<sp who="#arethuse #alphee">
                         <speaker>ARÉTHUSE et ALPHÉE.</speaker>
                         <l n="434">C'est une autre que moi qui règne dans votre âme,</l>
                         <l n="435">C'est un autre que moi qui règne dans votre âme,</l>
@@ -1133,7 +1118,7 @@
                         <l n="457">Vous en faites mon tourment,</l>
                         <l n="458">Et j'en ferai mon remède.</l>
                     </sp>
-<sp who="#arethuse_alphee">
+<sp who="#arethuse #alphee">
                         <speaker>ALPHÉE et ARÉTHUSE.</speaker>
                         <l n="459">Pour être heureux, il faut qu'on aime bien.</l>
                     </sp>
@@ -1245,7 +1230,7 @@
 </div>
 <div type="scene" n="8">
                     <head>SCÈNE VIII. Proserpine, Cyané, Arethuse, Pluton, Ascalaphe, troupe de nymphes, quatorze nymphes de la suite de Proserpine chantantes, huit nymphes dansantes.</head>
-<sp who="#proserpine_ses-nymphes">
+<sp who="#proserpine #nymphes">
                         <speaker>PROSERPINE et ses NYMPHES.</speaker>
                         <l n="529">Les beaux jours et la paix</l>
                         <l n="530">Sont revenus ensemble.</l>
@@ -1256,7 +1241,7 @@
                         <l n="532">Retirons-nous sous ce feuillage épais.</l>
                         <stage type="exit/hide/danse/sing">Pluton et Ascalaphe se retirent et se cachent, et Proserpine et ses nymphes s'avancent en dansant et en chantant.</stage>
                     </sp>
-<sp who="#proserpine_ses-nymphes">
+<sp who="#proserpine #nymphes">
                         <speaker>PROSERPINE et ses NYMPHES.</speaker>
                         <l n="533">Les beaux jours et la paix</l>
                         <l n="534">On ne voit plus de coeur qui tremble,</l>
@@ -1376,7 +1361,7 @@
                         <l n="602">Séparons-nous ; voyons qui sait le mieux</l>
                         <l n="603">Assortir les fleurs les plus belles.</l>
                     </sp>
-<sp who="#choeur-de-nymphes">
+<sp who="#nymphes">
                         <speaker>CHOEUR DE NYMPHES.</speaker>
                         <l n="604">Voyons qui sait le mieux</l>
                         <l n="605">Assortir les fleurs les plus belles.</l>
@@ -1423,7 +1408,7 @@
                         <speaker>PROSERPINE et CYANÉ.</speaker>
                         <l n="617">Ô ciel ! Protégez l'innocence !</l>
                     </sp>
-<sp who="#pluton_ascalaphe_divinites-infernales">
+<sp who="#pluton #ascalaphe #divinites-infernales">
                         <speaker>PLUTON, ASCALAPHE, et les divinités infernales descendant aux enfers avec Proserpine.</speaker>
                         <l n="618">Proserpine, ne craignez pas,</l>
                         <l n="619">Un dieu charmé de vos appas.</l>
@@ -1488,7 +1473,7 @@
                         <l n="653">N'a rien de plus affreux</l>
                         <l n="654">Que l'absence de ce qu'on aime.</l>
                     </sp>
-<sp who="#arethuse_alphee">
+<sp who="#arethuse #alphee">
                         <speaker>ALPHÉE et ARÉTHUSE.</speaker>
                         <l n="655">Le bonheur est partout où l'amour est en paix,</l>
                         <l n="656">Ne nous quittons jamais.</l>
@@ -1605,7 +1590,7 @@
                         <speaker>CYANÉ.</speaker>
                         <l n="708" part="M">C'est...</l>
                     </sp>
-<sp who="#ceres_le-choeur">
+<sp who="#ceres #le-choeur">
                         <speaker>CÉRÈS et LE CHOEUR.</speaker>
                         <l n="708" part="F">Ah ! Quel malheur nouveau !</l>
                         <stage type="silence/sad/transform">Cyané perd la voix et n'est plus qu'un ruisseau.</stage>
@@ -1807,7 +1792,7 @@
                         <l n="814">Est-ce une illusion dont le charme m'abuse,</l>
                         <l n="815">Est-ce toi, ma chère Arethuse ?</l>
                     </sp>
-<sp who="#arethuse_alphee">
+<sp who="#arethuse #alphee">
                         <speaker>ARÉTHUSE et ALPHÉE.</speaker>
                         <l n="816">Pluton veut qu'avec vous nous demeurions ici ;</l>
                         <l n="817">Nous suivons sans effort la loi qu'il nous impose.</l>
@@ -2240,7 +2225,7 @@
                         <l n="1054">Pourquoi Pluton inexorable</l>
                         <l n="1055">Veut-il dans les enfers l'accabler de douleur ?</l>
                     </sp>
-<sp who="#arethuse_alphee">
+<sp who="#arethuse #alphee">
                         <speaker>ALPHÉE et ARÉTHUSE.</speaker>
                         <l n="1056">C'est quelquefois un grand malheur</l>
                         <l n="1057">Que d'être trop aimable.</l>
@@ -2250,7 +2235,7 @@
                         <l n="1058">Pluton l'aime ! Et l'amour pour me désespérer</l>
                         <l n="1059">Fait soupirer un coeur qui doit être inflexible !</l>
                     </sp>
-<sp who="#arethuse_alphee">
+<sp who="#arethuse #alphee">
                         <speaker>ALPHÉE et ARÉTHUSE.</speaker>
                         <l n="1060">Quel coeur se peut assurer</l>
                         <l n="1061">D'être toujours insensible ?</l>
@@ -2266,7 +2251,7 @@
                         <speaker>ARÉTHUSE.</speaker>
                         <l n="1066">Elle est reine d'un vaste empire.</l>
                     </sp>
-<sp who="#arethuse_alphee">
+<sp who="#arethuse #alphee">
                         <speaker>ALPHÉE et ARÉTHUSE.</speaker>
                         <l n="1067">Il est beau de régner même dans les enfers.</l>
                     </sp>
@@ -2277,7 +2262,7 @@
                         <l n="1070">Je la perds, je perds tout espoir</l>
                         <l n="1071">Je ne pourrai jamais la voir.</l>
                     </sp>
-<sp who="#arethuse_alphee">
+<sp who="#arethuse #alphee">
                         <speaker>ALPHÉE et ARÉTHUSE.</speaker>
                         <l n="1072">Jupiter la demande, et l'enfer plein d'alarmes</l>
                         <l n="1073">Pour la garder a pris les armes.</l>

--- a/tei/quinault-roland.xml
+++ b/tei/quinault-roland.xml
@@ -86,9 +86,6 @@
                     <person xml:id="choeur-des-amours" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Amours</persName>
                     </person>
-                    <person xml:id="et-les-choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Et les Choeurs</persName>
-                    </person>
                     <person xml:id="le-petit-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Petit Choeur</persName>
                     </person>
@@ -128,14 +125,11 @@
                     <person xml:id="le-choeur-des-ombres-des-heros" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Choeur des Ombres des Heros</persName>
                     </person>
-                    <person xml:id="le-choeur-des-ombres-et-des-heros" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le Choeur des Ombres et des Heros</persName>
+                    <person xml:id="troupe-d-ombres-d-anciens-heros" sex="UNKNOWN">
+                        <persName>Troupe d'Ombres d'Anciens Héros</persName>
                     </person>
                     <person xml:id="la-gloire" sex="FEMALE">
                         <persName>La Gloire</persName>
-                    </person>
-                    <person xml:id="logistille-et-les-choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Logistille et les Choeurs</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -1070,7 +1064,7 @@
                         <speaker>CHOEUR DES AMOURS, qui sont autour de la fontaine.</speaker>
                         <l n="447">Aimez, aimez-vous.</l>
                     </sp>
-<sp who="#angelique #medor #et-les-choeurs">
+<sp who="#angelique #medor #les-choeurs">
                         <speaker>ANGÉLIQUE, MÉDOR, et LES CHOEURS.</speaker>
                         <l n="448">Aimons, aimons-nous.</l>
                     </sp>
@@ -1081,7 +1075,7 @@
                         <l n="451">L'amour vous appelle tous.</l>
                         <l n="452">Aimez, aimez-vous.</l>
                     </sp>
-<sp who="#angelique #medor #et-les-choeurs">
+<sp who="#angelique #medor #les-choeurs">
                         <speaker>ANGÉLIQUE, MÉDOR, et LES CHOEURS.</speaker>
                         <l n="453">L'amour nous appelle,</l>
                         <l n="454">Que sa flamme est belle !</l>
@@ -1093,7 +1087,7 @@
                         <l n="457">Il punit un coeur rebelle</l>
                         <l n="458">On n'évite point ses coups.</l>
                     </sp>
-<sp who="#angelique #medor #et-les-choeurs">
+<sp who="#angelique #medor #les-choeurs">
                         <speaker>ANGÉLIQUE, MÉDOR, et LES CHOEURS.</speaker>
                         <l n="459">Quel bien est plus doux</l>
                         <l n="460">Qu'un amour fidèle ?</l>
@@ -1102,7 +1096,7 @@
                         <speaker>CHOEUR DES AMOURS.</speaker>
                         <l n="461">Aimez, aimez-vous.</l>
                     </sp>
-<sp who="#angelique #medor #et-les-choeurs">
+<sp who="#angelique #medor #les-choeurs">
                         <speaker>ANGÉLIQUE, MÉDOR, et LES CHOEURS.</speaker>
                         <l n="462">Aimons, aimons-nous :</l>
                         <l n="463">L'amour nous appelle.</l>
@@ -2322,7 +2316,7 @@
                         <l n="1091">Quel héros, quel vainqueur</l>
                         <l n="1092">Est exempt de faiblesse ?</l>
                     </sp>
-<sp who="#le-choeur-des-ombres-et-des-heros">
+<sp who="#troupe-d-ombres-d-anciens-heros">
                         <speaker>LE CHOEUR DES OMBRES ET DES HÉROS.</speaker>
                         <l n="1093">Sortez pour jamais en ce jour</l>
                         <l n="1094">Des liens honteux de l'amour.</l>
@@ -2336,7 +2330,7 @@
                         <l n="1096">Allons, courons aux armes.</l>
                         <l n="1097">Que la gloire a de charmes !</l>
                     </sp>
-<sp who="#le-choeur-des-fees #le-choeur-des-ombres-et-des-heros">
+<sp who="#le-choeur-des-fees #troupe-d-ombres-d-anciens-heros">
                         <speaker>LE CHOEUR DES FÉES et LE CHOEUR DES OMBRES ET DES HÉROS.</speaker>
                         <l n="1098">Roland, courez aux armes</l>
                         <l n="1099">Que la gloire a de charmes.</l>
@@ -2355,7 +2349,7 @@
                         <l n="1105">Les maux que l'amour vous a faits.</l>
                         <stage type="get/fly/impatient/danse/happy/sing">Roland reprend ses armes que les fées et les héros lui présentent, il témoigne l'impatience qu'il a de partir pour obéir à la Gloire, et la Terreur vole devant lui. Les fées et les héros dansent pour témoigner leur joie ; et Logistille, le choeur de la suite de la Gloire, les choeurs des fées et des héros chantent ensemble.</stage>
                     </sp>
-<sp who="#logistille-et-les-choeurs">
+<sp who="#logistille #les-choeurs">
                         <speaker>LOGISTILLE ET LES CHOEURS.</speaker>
                         <l n="1106">La gloire vous appelle,</l>
                         <l n="1107">Ne soupirez plus que pour elle,</l>

--- a/tei/quinault-temple-de-la-paix.xml
+++ b/tei/quinault-temple-de-la-paix.xml
@@ -58,8 +58,11 @@
                     <person xml:id="choeurs-des-nymphes-des-bergers-et-des-bergeres" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeurs des Nymphes des Bergers et des Bergeres</persName>
                     </person>
-                    <person xml:id="amyntas-et-menalque" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Amyntas et Menalque</persName>
+                    <person xml:id="amyntas" sex="MALE">
+                        <persName>Amyntas</persName>
+                    </person>
+                    <person xml:id="menalque" sex="MALE">
+                        <persName>Menalque</persName>
                     </person>
                     <person xml:id="alcippe" sex="MALE">
                         <persName>Alcippe</persName>
@@ -239,7 +242,7 @@
 <stage type="casting">Mesdemoiselles de la Fontaine et Demathin, Bergères.</stage>
 <stage type="casting">BERGERS : Monsieur_le_Comte de Brionne, Messieurs Pécourt, Létang et Favier.</stage>
 <stage type="danse/explicit">Cette Danse est accompagnée d'une Chanson chantée par Amyntas et par Ménalque.</stage>
-<sp who="#amyntas-et-menalque">
+<sp who="#amyntas #menalque">
                         <speaker>AMYNTAS et MENALQUE.</speaker>
                         <l n="25">Charmant repos d'une vie innocente, </l>
                         <l n="26">Notre bonheur ne dépend que de vous. </l>

--- a/tei/quinault-thesee.xml
+++ b/tei/quinault-thesee.xml
@@ -73,8 +73,11 @@
                     <person xml:id="ceres" sex="MALE">
                         <persName>Cérès</persName>
                     </person>
-                    <person xml:id="choeur_graces" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Choeur_graces</persName>
+                    <person xml:id="choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Choeur</persName>
+                    </person>
+                    <person xml:id="graces" sex="UNKNOWN">
+                        <persName>Deux Grâces</persName>
                     </person>
                     <person xml:id="choeur-des-graces" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Graces</persName>
@@ -147,9 +150,6 @@
                     </person>
                     <person xml:id="choeur-des-habitants" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Habitants</persName>
-                    </person>
-                    <person xml:id="choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Choeur</persName>
                     </person>
                     <person xml:id="minerve" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Minerve</persName>
@@ -427,7 +427,7 @@
                         <l n="88">Que tout le reste de la terre</l>
                         <l n="89">Porte envie au bonheur de ces lieux pleins d'attraits.</l>
                     </sp>
-<sp who="#choeur_graces">
+<sp who="#choeur #graces">
                         <speaker>Le CHOEUR.</speaker>
                         <l n="90">Que tout le reste de la terre</l>
                         <l n="91">Porte envie au bonheur de ces lieux pleins d'attraits.</l>

--- a/tei/racine-plaideurs-69.xml
+++ b/tei/racine-plaideurs-69.xml
@@ -65,9 +65,6 @@
                     <person xml:id="isabelle" sex="FEMALE">
                         <persName>Isabelle</persName>
                     </person>
-                    <person xml:id="chicanneau_la-comtesse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Chicanneau_la Comtesse</persName>
-                    </person>
                     <person xml:id="le-souffleur" sex="MALE">
                         <persName>Le Souffleur</persName>
                     </person>
@@ -1893,7 +1890,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="530" part="F">Monsieur, je viens me plaindre aussi.</l>
                     </sp>
-<sp who="#chicanneau_la-comtesse">
+<sp who="#chicanneau #la-comtesse">
                         <speaker>CHICANNEAU, LA COMTESSE.</speaker>
                         <l n="531">Vous voyez devant vous mon adverse partie.</l>
                     </sp>

--- a/tei/regnard-arlequin-bonnes-fortunes.xml
+++ b/tei/regnard-arlequin-bonnes-fortunes.xml
@@ -66,9 +66,6 @@
                     <person xml:id="brocantin" sex="MALE">
                         <persName>Brocantin</persName>
                     </person>
-                    <person xml:id="isabelle_colombine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Isabelle_colombine</persName>
-                    </person>
                     <person xml:id="le-fiacre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Fiacre</persName>
                     </person>
@@ -1160,7 +1157,7 @@
 	<s n="3">Puisque vous êtes si raisonnables, apprenez donc que je suis en pourparler de mariage ; mais c'est pour vous. </s>
 </p>
                     </sp>
-<sp who="#isabelle_colombine">
+<sp who="#isabelle #colombine">
                         <speaker>ISABELLE et COLOMBINE, ensemble. </speaker>
                         <p n="23">
 	<s n="1">Ali, mon père ! </s>

--- a/tei/regnard-carnaval-de-venise.xml
+++ b/tei/regnard-carnaval-de-venise.xml
@@ -66,9 +66,6 @@
                     <person xml:id="isabelle" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Isabelle</persName>
                     </person>
-                    <person xml:id="isabelle_leonore" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Isabelle_leonore</persName>
-                    </person>
                     <person xml:id="leandre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Leandre</persName>
                     </person>
@@ -86,9 +83,6 @@
                     </person>
                     <person xml:id="un-armenien" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Armenien</persName>
-                    </person>
-                    <person xml:id="isabelle_leandre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Isabelle_leandre</persName>
                     </person>
                     <person xml:id="rodolphe" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Rodolphe</persName>
@@ -445,7 +439,7 @@
                         <speaker>ISABELLE.</speaker>
                         <l n="135">Nommez-moi cet objet de votre amour nouvelle. </l>
                     </sp>
-<sp who="#isabelle_leonore">
+<sp who="#isabelle #leonore">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="136">C'est Léandre. Qu'entends-je ? Ô dieux ! </l>
                     </sp>
@@ -744,7 +738,7 @@
                         <l n="272">Vos beaux yeux et vos charmes </l>
                         <l n="273">Vous répondront de mon ardeur. </l>
                     </sp>
-<sp who="#isabelle_leandre">
+<sp who="#isabelle #leandre">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="274">Goûtons, sans nous contraindre, </l>
                         <l n="275">Les plaisirs les plus doux. </l>

--- a/tei/regnard-joueur.xml
+++ b/tei/regnard-joueur.xml
@@ -67,17 +67,17 @@
                     <person xml:id="laquais" sex="MALE">
                         <persName>Un Laquais d'Angélique</persName>
                     </person>
-                    <person xml:id="le_marquis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Le_marquis</persName>
+                    <person xml:id="le-marquis" sex="MALE">
+                        <persName>Le Marquis</persName>
                     </person>
-                    <person xml:id="numer_laquais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numer_laquais</persName>
+                    <person xml:id="laquais-1er" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Laquais 1er</persName>
                     </person>
-                    <person xml:id="numnd_laquais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numnd_laquais</persName>
+                    <person xml:id="laquais-2nd" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Laquais 2nd</persName>
                     </person>
-                    <person xml:id="numeme_laquais" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numeme_laquais</persName>
+                    <person xml:id="laquais-3eme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Laquais 3eme</persName>
                     </person>
                     <person xml:id="madame-la-ressource" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Madame la Ressource</persName>
@@ -90,9 +90,6 @@
                     </person>
                     <person xml:id="monsieur-galonier" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Monsieur Galonier</persName>
-                    </person>
-                    <person xml:id="mme_adam_m_galonier" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Mme_adam_m_galonier</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -1516,7 +1513,7 @@
 </div>
 <div type="scene" n="4">
                     <head>SCÈNE IV. Le Marquis, La Comtesse, Angélique, Nérine.</head>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>Le Marquis, se rajustant, à la Comtesse.</speaker>
                         <l n="507">Je suis tout en désordre : un maudit embarras</l>
                         <l n="508">M'a fait quitter ma chaise à deux ou trois cents pas ;</l>
@@ -1527,7 +1524,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="511">Que monsieur le Marquis est galant sans fadeur !</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="512">Oh ! Point du tout, je suis votre humble serviteur.</l>
                         <l n="513">Mais, à vous parler net, sans que l'esprit fatigue,</l>
@@ -1539,7 +1536,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="516" part="I">C'est ma soeur.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="516" part="F">Votre soeur ! Vraiment, c'est fort bien fait.</l>
                         <l n="517">Je vous sais gré d'avoir une soeur aussi belle ;</l>
@@ -1550,7 +1547,7 @@
                         <l n="519">Comme à tout ce qu'il dit il donne un joli tour !</l>
                         <l n="520">Qu'il est sincère ! On voit qu'il est homme de cour.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="521">Homme de cour, moi ! Non. Ma foi, la cour m'ennuie ;</l>
                         <l n="522">L'esprit de ce pays n'est qu'en superficie ;</l>
@@ -1565,7 +1562,7 @@
                         <speaker>NÉRINE.</speaker>
                         <l n="529">Il vous est obligé, Monsieur, de tant de peine.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="530">Je n'y suis pas plus tôt, soudain je perds haleine.</l>
                         <l n="531">Ces fades compliments sur de grands mots montés,</l>
@@ -1579,7 +1576,7 @@
                         <speaker>ANGELIQUE, au Marquis.</speaker>
                         <l n="537">Les dames de la cour sont bien mieux votre affaire ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="538">Point. Il faut être au moins gros fermier pour leur plaire :</l>
                         <l n="539">Leur sotte vanité croit ne pouvoir trop haut</l>
@@ -1600,7 +1597,7 @@
                         <l n="550" part="F">La manière est facile ;</l>
                         <l n="551">Et ce commerce-là me paraît assez doux.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>Le Marquis, à la Comtesse.</speaker>
                         <l n="552">C'est ainsi que je veux en user avec vous.</l>
                         <l n="553">Je suis tout naturel, et j'aime la franchise :</l>
@@ -1614,7 +1611,7 @@
                         <l n="558">Vous me parlez, Marquis, une langue inconnue :</l>
                         <l n="559">Le mot d'amour me blesse, et me fait trouver mal.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="560">L'effet n'en serait pas peut-être si fatal.</l>
                     </sp>
@@ -1634,7 +1631,7 @@
                         <l n="566">Que mortel, quel qu'il soit, ne me dit de ma vie</l>
                         <l n="567">Un mot douteux qui pût effleurer mon honneur.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="568">Croirait-on qu'une veuve aurait tant de pudeur ?</l>
                     </sp>
@@ -1642,7 +1639,7 @@
                         <speaker>ANGÉLIQUE.</speaker>
                         <l n="569" part="I">Mais Valère vous aime : et souvent...</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="569" part="F">Qu'est-ce à dire,</l>
                         <l n="570">Valère ? Un autre ici conjointement soupire !</l>
@@ -1653,7 +1650,7 @@
                         <speaker>NÉRINE.</speaker>
                         <l n="572" part="M">Ici.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>Le Marquis fait semblant de s'en aller et revient.</speaker>
                         <l n="572" part="F">Nous nous verrons dans peu.</l>
                     </sp>
@@ -1661,7 +1658,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="573" part="I">Mais quel droit avez-vous sur moi ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="573" part="F">Quel droit, ma reine ?</l>
                         <l n="574">Le droit de bienséance avec celui d'aubaine.</l>
@@ -1672,7 +1669,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="577">Vous êtes fou, Marquis, de parler de la sorte.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="578">Je sais ce que je dis, ou le diable m'emporte.</l>
                     </sp>
@@ -1680,7 +1677,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="579">Sommes-nous donc liés par quelque engagement ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="580" part="I">Non pas autrement... mais...</l>
                     </sp>
@@ -1689,7 +1686,7 @@
                         <l n="580" part="F">Qu'est-ce à dire ? Comment ? ...</l>
                         <l n="581" part="I">Parlez.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="581" part="F">Je ne sais point prendre en main des trompettes,</l>
                         <l n="582">Pour publier partout les faveurs qu'on m'a faites.</l>
@@ -1702,7 +1699,7 @@
                         <speaker>NÉRINE.</speaker>
                         <l n="583" part="M">Des faveurs !</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="583" part="F">Suffit, je suis discret ;</l>
                         <l n="584">Et sais, quand il le faut, oublier un secret.</l>
@@ -1712,7 +1709,7 @@
                         <l n="585">On ne connaît que trop ma retenue austère.</l>
                         <l n="586" part="I">Il veut rire.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="586" part="F">Ah ! Parbleu, je saurai de Valère</l>
                         <l n="587">Quel est, en vous aimant, le but de ses désirs,</l>
@@ -1721,11 +1718,11 @@
 </div>
 <div type="scene" n="5">
                     <head>SCÈNE V. Angélique, La Comtesse, Le Marquis, Nérine, un laquais.</head>
-<sp who="#numer_laquais">
+<sp who="#laquais-1er">
                         <speaker>Le Laquais, rendant un billet au Marquis.</speaker>
                         <l n="589">Monsieur, c'est de la part de la grosse comtesse.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>Le Marquis, le mettant dans sa poche.</speaker>
                         <l n="590" part="I">Je le lirai tantôt.</l>
                         <stage type="exit">Le laquais sort.</stage>
@@ -1733,12 +1730,12 @@
 </div>
 <div type="scene" n="6">
                     <head>SCÈNE VI. Angélique, la Comtesse, le Marquis, Nérine, un second laquais.</head>
-<sp who="#numnd_laquais">
+<sp who="#laquais-2nd">
                         <speaker>Second Laquais.</speaker>
                         <l n="590" part="F">Cette jeune duchesse</l>
                         <l n="591">Vous attend à vingt pas pour vous mener au jeu.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="592" part="I">Qu'elle attende.</l>
                         <stage type="exit">Le second laquais sort.</stage>
@@ -1746,22 +1743,22 @@
 </div>
 <div type="scene" n="7">
                     <head>SCÈNE VII. Angélique, la Comtesse, le Marquis, Nérine, un troisième laquais.</head>
-<sp who="#numeme_laquais">
+<sp who="#laquais-3eme">
                         <speaker> Le Troisième Laquais.</speaker>
                         <l n="592" part="M">Monsieur...</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="592" part="F">Encore ! Ah ! Palsambleu,</l>
                         <l n="593">Il faut que de la ville enfin je me dérobe.</l>
                     </sp>
-<sp who="#numeme_laquais">
+<sp who="#laquais-3eme">
                         <speaker> Le Troisième Laquais.</speaker>
                         <l n="594">Je viens de voir, Monsieur, cette femme de robe,</l>
                         <l n="595">Qui dit que cette nuit son mari couche aux champs,</l>
                         <l n="596" part="I">Et que ce soir, sans bruit...</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="596" part="F">Il suffit, je t'entends.</l>
                         <l n="597">Tu prendras ce manteau, fait pour bonne fortune,</l>
@@ -1769,7 +1766,7 @@
                         <l n="599">Va m'attendre en secret où tu fus avant-hier,</l>
                         <l n="600" part="I">Là...</l>
                     </sp>
-<sp who="#numeme_laquais">
+<sp who="#laquais-3eme">
                         <speaker> Le Troisième Laquais.</speaker>
                         <l n="600" part="M">Je sais.</l>
                         <stage type="exit">Il sort.</stage>
@@ -1777,7 +1774,7 @@
 </div>
 <div type="scene" n="8">
                     <head>SCÈNE VIII. Angélique, La Comtesse, Le Marquis, Nérine.</head>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="600" part="F">Il faudrait avoir un corps de fer</l>
                         <l n="601">Pour résister à tout. J'ai de l'ouvrage à faire,</l>
@@ -1789,7 +1786,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="604">Si mon coeur était libre, il pourrait être à vous.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="605">Adieu, charmant objet : à regret je vous quitte.</l>
                         <l n="606">C'est un pesant fardeau d'avoir un gros mérite.</l>
@@ -3190,7 +3187,7 @@
                         <speaker>HECTOR.</speaker>
                         <l n="1055" part="F">Allez, laissez-moi faire.</l>
                     </sp>
-<sp who="#mme_adam_m_galonier">
+<sp who="#madame-adam #monsieur-galonier">
                         <speaker>Madame ADAM et Monsieur GALONIER, ensemble.</speaker>
                         <l n="1056" part="I">Mais, monsieur...</l>
                     </sp>
@@ -3230,7 +3227,7 @@
                         <speaker>HECTOR.</speaker>
                         <l n="1063" part="F">Oui, de notre comtesse.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, vers la coulisse.</speaker>
                         <l n="1064">Que ma chaise se tienne à deux cents pas d'ici.</l>
                         <l n="1065">Et vous, mes trois laquais, éloignez-vous aussi :</l>
@@ -3244,7 +3241,7 @@
                         <speaker>HECTOR, à Valère.</speaker>
                         <l n="1066" part="F">Que prétend-il donc faire ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, à Valère.</speaker>
                         <l n="1067">N'est-ce pas vous, Monsieur, qui vous nommez Valère ?</l>
                     </sp>
@@ -3252,7 +3249,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="1068">Oui, monsieur ; c'est ainsi qu'on m'a toujours nommé.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1069">Jusques au fond du coeur j'en suis, parbleu, charmé.</l>
                         <l n="1070">Faites que ce valet à l'écart se retire.</l>
@@ -3272,7 +3269,7 @@
 </div>
 <div type="scene" n="11">
                     <head>SCÈNE XI. Le Marquis, Valère.</head>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1072" part="I">Savez-vous qui je suis ?</l>
                     </sp>
@@ -3280,7 +3277,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="1072" part="F">Je n'ai pas cet honneur.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, à part.</speaker>
                         <l n="1073">Courage ; allons, Marquis, montre de la vigueur : il craint.</l>
                         <stage type="loud">Haut.</stage>
@@ -3305,7 +3302,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="1090" part="I">On le voit à votre air.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1090" part="F">J'ai, sur certaine femme</l>
                         <l n="1091">Jeté, sans y songer, quelque amoureuse flamme.</l>
@@ -3320,7 +3317,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="1098">Je ne crois pas,Monsieur, qu'on fût si téméraire.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1099">On m'assure pourtant que vous le voulez faire.</l>
                     </sp>
@@ -3328,7 +3325,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="1100" part="I">Moi ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1100" part="F">Que, sans respecter ni rang, ni qualité,</l>
                         <l n="1101">Vous nourrissez dans l'âme une velléité</l>
@@ -3339,7 +3336,7 @@
                         <l n="1102" part="F">C'est pure médisance ;</l>
                         <l n="1103">Je sais ce qu'entre nous le sort mit de distance.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, bas.</speaker>
                         <l n="1104" part="I">Il tremble.</l>
                         <stage type="loud">Haut.</stage>
@@ -3350,7 +3347,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="1106" part="I">Je le sais.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1106" part="F">Vous croyez, en votre humeur caustique,</l>
                         <l n="1107">En agir avec moi comme avec l'as de pique.</l>
@@ -3359,7 +3356,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="1108" part="I">Moi, monsieur ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, bas.</speaker>
                         <l n="1108" part="M">Il me craint.</l>
                         <stage type="loud">Haut.</stage>
@@ -3376,7 +3373,7 @@
                         <speaker>VALÈRE, mettant la main sur son épée.</speaker>
                         <l n="1111" part="F">Vous le voulez donc ? Il faut vous satisfaire.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1112" part="I">Bon ! Bon ! Je ris.</l>
                     </sp>
@@ -3386,7 +3383,7 @@
                         <l n="1113">Et vos airs insolents ne plaisent point du tout.</l>
                         <l n="1114" part="I">Vous êtes un faquin.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1114" part="F">Cela vous plaît à dire.</l>
                     </sp>
@@ -3394,7 +3391,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="1115" part="I">Un fat, un malheureux.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1115" part="F">Monsieur, vous voulez rire.</l>
                     </sp>
@@ -3403,7 +3400,7 @@
                         <l n="1116">Il faut voir sur-le-champ si les vice-baillis</l>
                         <l n="1117">Sont si francs du collier que vous l'avez promis.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1118">Mais faut-il nous brouiller pour un sot point de gloire ?</l>
                     </sp>
@@ -3411,7 +3408,7 @@
                         <speaker>VALÈRE.</speaker>
                         <l n="1119">Oh ! Le vin est tiré, monsieur ; il le faut boire.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, criant.</speaker>
                         <l n="1120" part="I">Ah ! Ah ! Je suis blessé.</l>
                     </sp>
@@ -3422,7 +3419,7 @@
                         <speaker>HECTOR, accourant.</speaker>
                         <l n="1120" part="F">Quels desseins emportés ? ...</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, mettant l'épée à la main.</speaker>
                         <l n="1121" part="I">Ah ! C'est trop endurer.</l>
                     </sp>
@@ -3430,7 +3427,7 @@
                         <speaker>HECTOR, au Marquis.</speaker>
                         <l n="1121" part="F">Ah ! Monsieur, arrêtez.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, à Hector.</speaker>
                         <l n="1122" part="I">Laissez-moi donc.</l>
                     </sp>
@@ -3447,7 +3444,7 @@
                         <speaker>HECTOR, au Marquis.</speaker>
                         <l n="1124" part="I">Quel sujet ? ...</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, fièrement à Hector.</speaker>
                         <l n="1124" part="F">Votre maître a certains petits airs...</l>
                         <stage type="closer/frighten/slow">Valère s'approche du Marquis. Le Marquis effrayé, dit doucement.</stage>
@@ -3460,7 +3457,7 @@
                         <speaker>HECTOR, au Marquis.</speaker>
                         <l n="1129" part="I">Mais encor quel sujet ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, à Hector.</speaker>
                         <l n="1129" part="F">Quel sujet ? Moins que rien.</l>
                         <l n="1130">L'amour de la Comtesse auprès de lui m'appelle...</l>
@@ -3472,7 +3469,7 @@
                         <l n="1133">Sur notre patrimoine ainsi jeter les yeux !</l>
                         <l n="1134">Attaquer la Comtesse, et nous le dire encore !</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, à Hector.</speaker>
                         <l n="1135">Bon ! Je ne l'aime pas ; c'est elle qui m'adore.</l>
                     </sp>
@@ -3488,7 +3485,7 @@
                         <l n="1140">Oui, les droits sur le coeur ; mais sur la bourse,</l>
                         <l n="1141" part="I">Non.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, à part, mettant son épée dans le fourreau.</speaker>
                         <l n="1141" part="F">Je le savais bien, moi, que j'en aurais raison ;</l>
                         <l n="1142">Et voilà comme il faut se tirer d'une affaire.</l>
@@ -3497,7 +3494,7 @@
                         <speaker>HECTOR, au Marquis.</speaker>
                         <l n="1143">N'auriez-vous point besoin d'un peu d'eau vulnéraire ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, à Valère.</speaker>
                         <l n="1144">Je suis ravi de voir que vous ayez du coeur,</l>
                         <l n="1145">Et que le tout se soit passé dans la douceur.</l>
@@ -3924,7 +3921,7 @@
 </div>
 <div type="scene" n="9">
                     <head>SCÈNE IX. Le Marquis, la Comtesse.</head>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1306">À mon bonheur enfin, Madame, tout conspire :</l>
                         <l n="1307" part="I">Vous êtes tout à moi.</l>
@@ -3934,7 +3931,7 @@
                         <l n="1307" part="F">Que voulez-vous donc dire,</l>
                         <l n="1308" part="I">Marquis ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1308" part="F">Que mon amour n'a plus de concurrent ;</l>
                         <l n="1309">Que je suis et serai votre seul conquérant ;</l>
@@ -3945,7 +3942,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1312" part="I">Moi ! Que l'on m'escalade ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1312" part="F">Entre nous, sans façon,</l>
                         <l n="1313">À Valère de près j'ai serré le bouton :</l>
@@ -3955,7 +3952,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1315" part="I">Hé ! Le petit poltron !</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1315" part="F">Oh ! Palsambleu, Madame,</l>
                         <l n="1316">Il serait un Achille, un Pompée, un César,</l>
@@ -3969,7 +3966,7 @@
                         <l n="1320">Vous ne connaissez pas, Marquis, tout votre mal ;</l>
                         <l n="1321">Vous avez à combattre encor plus d'un rival.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1322">Le don de votre coeur couvre un peu trop de gloire</l>
                         <l n="1323">Pour n'être que le prix d'une seule victoire.</l>
@@ -3980,7 +3977,7 @@
                         <l n="1324" part="F">Non, non, je ne veux pas</l>
                         <l n="1325">Vous exposer sans cesse à de nouveaux combats.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1326">Est-ce ce financier de noblesse mineure,</l>
                         <l n="1327">Qui s'est fait depuis peu gentilhomme en une heure ;</l>
@@ -3999,7 +3996,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1338">À vos transports jaloux un autre se dérobe.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1339">C'est donc ce sénateur, cet Adonis de robe,</l>
                         <l n="1340">Ce docteur en soupers, qui se tait au palais,</l>
@@ -4013,7 +4010,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1346">Non, Marquis, c'est Dorante ; et j'ai su m'en défaire.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1347">Quoi ! Dorante ! Cet homme à maintien débonnaire,</l>
                         <l n="1348">Ce croquant, qu'à l'instant je viens de voir sortir ?</l>
@@ -4022,7 +4019,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1349" part="I">C'est lui-même.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1349" part="F">Eh ! Parbleu, vous deviez m'avertir ;</l>
                         <l n="1350">Nous nous serions parlé sans sortir de la salle.</l>
@@ -4035,7 +4032,7 @@
                         <l n="1354">Vous êtes turbulent. Si vous étiez plus sage,</l>
                         <l n="1355" part="I">On pourrait...</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1355" part="F">La sagesse est tout mon apanage.</l>
                     </sp>
@@ -4044,7 +4041,7 @@
                         <l n="1356">Quoiqu'un engagement m'ait toujours fait horreur,</l>
                         <l n="1357">On aurait avec vous quelque affaire de coeur.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1358">Ah ! Parbleu, volontiers. Vous me chatouillez l'âme.</l>
                         <l n="1359">Par affaire de coeur, qu'entendez-vous, Madame ?</l>
@@ -4053,7 +4050,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1360">Ce que vous entendez vous-même assurément.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1361">Est-ce pour mariage, ou bien pour autrement ?</l>
                     </sp>
@@ -4061,7 +4058,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1362">Quoi ! Vous prétendriez, si j'avais la foiblesse...</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1363">Ah ! Ma foi ! L'on n'a plus tant de délicatesse ;</l>
                         <l n="1364">On s'aime pour s'aimer tout autant que l'on peut</l>
@@ -4074,7 +4071,7 @@
                         <l n="1368">Je veux un bon contrat sur de bon parchemin,</l>
                         <l n="1369">Et non pas un hymen qu'on rompt le lendemain.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1370">Vous aimez chastement, je vous en félicite,</l>
                         <l n="1371">Et je me donne à vous avec tout mon mérite,</l>
@@ -4085,7 +4082,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1374">Je crois que nos deux coeurs seront toujours fidèles.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1375">Oh ! Parbleu, nous vivrons comme deux tourterelles.</l>
                         <l n="1376">Pour vous porter, Madame, un coeur tout dégagé,</l>
@@ -4101,7 +4098,7 @@
 </div>
 <div type="scene" n="10">
                     <head>SCÈNE X.</head>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, seul.</speaker>
                         <l n="1382">Eh bien ! Marquis, tu vois, tout rit à ton mérite ;</l>
                         <l n="1383">Le rang, le coeur, le bien, tout pour toi sollicite :</l>
@@ -4132,7 +4129,7 @@
                         <l n="1402">Attendez un moment. Quelle ardeur vous transporte ?</l>
                         <l n="1403">Hé quoi ! Monsieur, tout seul vous sautez de la sorte !</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1404">C'est un pas de ballet que je veux repasser.</l>
                     </sp>
@@ -4141,7 +4138,7 @@
                         <l n="1405">Mon maître, qui me suit, vous le fera danser,</l>
                         <l n="1406" part="I">Monsieur, si vous voulez.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1406" part="F">Que dis-tu là ? Ton maître !</l>
                     </sp>
@@ -4149,7 +4146,7 @@
                         <speaker>HECTOR.</speaker>
                         <l n="1407">Oui, monsieur, à l'instant vous l'allez voir paraître.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1408">En ces lieux je ne puis plus longtemps m'arrêter ;</l>
                         <l n="1409">Pour cause, nous devons tous deux nous éviter.</l>
@@ -4657,7 +4654,7 @@
 </div>
 <div type="scene" n="4">
                     <head>SCÈNE IV. Le Marquis, la Comtesse, Angélique, Dorante, Madame La Ressource, Nérine.</head>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>Le Marquis, à la Comtesse.</speaker>
                         <l n="1610">Charmé de vos beautés, je viens enfin, Madame,</l>
                         <l n="1611">Ici mettre à vos pieds et mon corps et mon âme.</l>
@@ -4674,7 +4671,7 @@
                         <l n="1615">De m'unir avec vous le reste de ma vie.</l>
                         <l n="1616">Vous êtes gentilhomme et cela me suffit.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1617" part="I">Je le suis du déluge.</l>
                     </sp>
@@ -4682,7 +4679,7 @@
                         <speaker>MADAME LA RESSOURCE, à part.</speaker>
                         <l n="1617" part="F">Oui, c'est lui qui le dit.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1618">En faisant avec moi cette heureuse alliance,</l>
                         <l n="1619">Vous pourrez vous vanter que gentilhomme en France</l>
@@ -4698,7 +4695,7 @@
                         <speaker>NÉRINE, au Marquis.</speaker>
                         <l n="1624" part="I">Vous la connaissez ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1624" part="F">Moi ? Je ne sais ce que c'est.</l>
                     </sp>
@@ -4709,7 +4706,7 @@
                         <l n="1627">Fait du temps du déluge, à me payer ma somme,</l>
                         <l n="1628">Mes quatre cents écus prêtés depuis cinq ans ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1629">Pour me les demander, vous prenez bien le temps.</l>
                     </sp>
@@ -4718,7 +4715,7 @@
                         <l n="1630">Je veux, aux yeux de tous, vous en faire avanie,</l>
                         <l n="1631" part="I">À toute heure, en tous lieux.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1631" part="F">Hé ! Vous rêvez, ma mie.</l>
                     </sp>
@@ -4741,7 +4738,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1636" part="I">Comment donc ?</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS, à part.</speaker>
                         <l n="1636" part="M">Ah ! Je grille.</l>
                     </sp>
@@ -4760,7 +4757,7 @@
                         <l n="1639">Je suis Marquise donc, moi qui suis sa cousine ?</l>
                         <l n="1640">Son père était huissier à verge dans Le Mans.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1641" part="I">Vous en avez menti.</l>
                         <stage type="aparte">À part.</stage>
@@ -4770,7 +4767,7 @@
                         <speaker>MADAME LA RESSOURCE.</speaker>
                         <l n="1642">Mon oncle n'était pas huissier ? Qu'il t'en souvienne.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1643">Son nom était connu dans le haut et bas Maine.</l>
                     </sp>
@@ -4787,7 +4784,7 @@
                         <l n="1646">C'est moi qui l'ai nourri quatre mois sans reproche,</l>
                         <l n="1647">Quand il vint à Paris en guêtres, par le coche.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1648">D'accord, puisqu'on le sait, mon père était huissier,</l>
                         <l n="1649">Mais huissier à cheval ; c'est comme chevalier.</l>
@@ -4800,7 +4797,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1653" part="F">Taisez-vous, insolent.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1654">Insolent ! Moi qui dois honorer votre couche,</l>
                         <l n="1655">Et par qui vous devez quelque jour faire souche !</l>
@@ -4809,7 +4806,7 @@
                         <speaker>LA COMTESSE.</speaker>
                         <l n="1656">Sors d'ici, malheureux ; porte ailleurs ton amour.</l>
                     </sp>
-<sp who="#le_marquis">
+<sp who="#le-marquis">
                         <speaker>LE MARQUIS.</speaker>
                         <l n="1657">Oui ! L'on agit de même avec les gens de cour !</l>
                         <l n="1658">On reconnaît si mal le rang et le mérite !</l>

--- a/tei/rochefort-dupeuty-livry-madame-gregoire.xml
+++ b/tei/rochefort-dupeuty-livry-madame-gregoire.xml
@@ -116,9 +116,6 @@
                     <person xml:id="tous-deux" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous Deux</persName>
                     </person>
-                    <person xml:id="madame-gregoire-et-d-auberval" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Madame Gregoire et D Auberval</persName>
-                    </person>
                     <person xml:id="tous-trois" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Tous Trois</persName>
                     </person>
@@ -3792,7 +3789,7 @@ la table, est occupée à servir. - D Auberval découpe.</stage>
 </p>
                         <stage type="together">ENSEMBLE.</stage>
                     </sp>
-<sp who="#madame-gregoire-et-d-auberval">
+<sp who="#madame-gregoire #d-auberval">
                         <speaker>MADAME GRÉGOIRE et D'AUBERVAL.</speaker>
                         <ab type="chanson"><!--<poem>-->
 <lg n="1">

--- a/tei/rosimond-festin-de-pierre.xml
+++ b/tei/rosimond-festin-de-pierre.xml
@@ -90,11 +90,11 @@
                     <person xml:id="amarille" sex="FEMALE">
                         <persName>Amarille</persName>
                     </person>
-                    <person xml:id="numere-voix" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numere Voix</persName>
+                    <person xml:id="voix-1ere" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Voix 1ere</persName>
                     </person>
-                    <person xml:id="numeme-voix" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numeme Voix</persName>
+                    <person xml:id="voix-2eme" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Voix 2eme</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -4008,7 +4008,7 @@
 </div>
 <div type="scene" n="6">
                     <head>SCÈNE VI. Deux Voix aux deux côtés du théâtre, Carrille, Don Juan.</head>
-<sp who="#numere-voix">
+<sp who="#voix-1ere">
                         <speaker>1ère VOIX. </speaker>
                         <l n="1377" part="I">Don Juan !</l>
                     </sp>
@@ -4016,7 +4016,7 @@
                         <speaker>DON JUAN.</speaker>
                         <l n="1377" part="M">Quelle voix ?</l>
                     </sp>
-<sp who="#numeme-voix">
+<sp who="#voix-2eme">
                         <speaker>2ème VOIX.</speaker>
                         <l n="1377" part="M">Don Juan !</l>
                     </sp>
@@ -4028,7 +4028,7 @@
                         <speaker>CARRILLE.</speaker>
                         <l n="1378">L'Ombre vient vous quérir, allez vite après elle.</l>
                     </sp>
-<sp who="#numere-voix">
+<sp who="#voix-1ere">
                         <speaker>1ère VOIX. </speaker>
                         <l n="1379">Don Juan ton heure s'approche, </l>
                         <l n="1380">C'est moi qui t'en viens avertir, </l>
@@ -4058,7 +4058,7 @@
                         <l n="1392">Ô toi ! Qui que tu sois qui me prêche pour eux, </l>
                         <l n="1393">Ne t'imagine pas que je change de vie.</l>
                     </sp>
-<sp who="#numeme-voix">
+<sp who="#voix-2eme">
                         <speaker>2ème VOIX. </speaker>
                         <l n="1394">De tourments infinis, tu la verras suivie.</l>
                     </sp>
@@ -4066,7 +4066,7 @@
                         <speaker>DON JUAN.</speaker>
                         <l n="1395" part="I">Autre donneur d'avis.</l>
                     </sp>
-<sp who="#numeme-voix">
+<sp who="#voix-2eme">
                         <speaker>2ème VOIX. </speaker>
                         <l n="1395" part="F">Ah ! Don Juan, tu te perds, </l>
                         <l n="1396">Pour avoir pratiqué tant de noires maximes. </l>
@@ -4080,7 +4080,7 @@
                         <l n="1401">Sont-ce nos deux amis qui parlent de la sorte, </l>
                         <l n="1402" part="I">Je les ai vus périr, Dieux !</l>
                     </sp>
-<sp who="#numere-voix">
+<sp who="#voix-1ere">
                         <speaker>1ère VOIX. </speaker>
                         <l n="1402" part="F">Leur puissance est forte, </l>
                         <l n="1403" part="I">Les nommant tu les crois.</l>

--- a/tei/rotrou-antigone.xml
+++ b/tei/rotrou-antigone.xml
@@ -74,14 +74,11 @@
                     <person xml:id="argie" sex="FEMALE">
                         <persName>Argie</persName>
                     </person>
-                    <person xml:id="adraste-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Adraste</persName>
+                    <person xml:id="capitaine-1er" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Capitaine 1er</persName>
                     </person>
-                    <person xml:id="numer-capitaine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numer Capitaine</persName>
-                    </person>
-                    <person xml:id="numnd-capitaine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Numnd Capitaine</persName>
+                    <person xml:id="capitaine-2nd" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Capitaine 2nd</persName>
                     </person>
                     <person xml:id="menette" sex="MALE">
                         <persName>Ménette</persName>
@@ -652,7 +649,7 @@
                         <l n="336">Quel emploi t'a déjà tant de fois retenu ?</l>
                         <l n="337">Il ne faut point d'apprêt à paraître tout nu.</l>
                     </sp>
-<sp who="#numer-capitaine">
+<sp who="#capitaine-1er">
                         <speaker>Premier CAPITAINE.</speaker>
                         <l n="338">En ces effets bien moins de valeur que de rage.</l>
                         <l n="339">La nature, Seigneur, dispense le courage ;</l>
@@ -809,7 +806,7 @@
                         <speaker>HÉMON.</speaker>
                         <l n="451">Détourner s'il se peut une étrange infortune.</l>
                     </sp>
-<sp who="#numnd-capitaine">
+<sp who="#capitaine-2nd">
                         <speaker>Second CAPITAINE.</speaker>
                         <l n="452">C'est leur mère. Ô nature ! Assiste son dessein.</l>
                     </sp>
@@ -1109,7 +1106,7 @@
                         <l n="643">Pour vous persécuter même jusqu'au trépas.</l>
                         <stage type="exit">Elle sort furieuse.</stage>
                     </sp>
-<sp who="#numer-capitaine">
+<sp who="#capitaine-1er">
                         <speaker>Premier CAPITAINE.</speaker>
                         <l n="644" part="I">Son entremise est vaine.</l>
                     </sp>

--- a/tei/rotrou-cleagenor.xml
+++ b/tei/rotrou-cleagenor.xml
@@ -56,26 +56,23 @@
                     <person xml:id="ozanor" sex="MALE">
                         <persName>Ozanor</persName>
                     </person>
-                    <person xml:id="premier_voleur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Premier_voleur</persName>
+                    <person xml:id="premier-voleur" sex="MALE">
+                        <persName>Premier Voleur</persName>
                     </person>
-                    <person xml:id="deuxieme_voleur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Deuxieme_voleur</persName>
-                    </person>
-                    <person xml:id="premier_archer" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Premier_archer</persName>
-                    </person>
-                    <person xml:id="deuxieme_archer" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Deuxieme_archer</persName>
+                    <person xml:id="deuxieme-voleur" sex="MALE">
+                        <persName>Deuxième Voleur</persName>
                     </person>
                     <person xml:id="premier-archer" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Premier Archer</persName>
                     </person>
+                    <person xml:id="deuxieme-archer" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Deuxieme Archer</persName>
+                    </person>
                     <person xml:id="philemond" sex="FEMALE">
                         <persName>Philemond</persName>
                     </person>
-                    <person xml:id="suite_de_theandre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Suite_de_theandre</persName>
+                    <person xml:id="suite-de-theandre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Suite de Theandre</persName>
                     </person>
                     <person xml:id="conseiller" sex="MALE">
                         <persName>Le Conseiller</persName>
@@ -715,17 +712,17 @@
 </div>
 <div type="scene" n="4">
                     <head>SCÈNE IV. Deux Voleurs, Doristée.</head>
-<sp who="#premier_voleur">
+<sp who="#premier-voleur">
                         <speaker>1er VOLEUR.</speaker>
                         <l n="324">Ami, vois cet homme assis en cette plaine.</l>
                     </sp>
-<sp who="#deuxieme_voleur">
+<sp who="#deuxieme-voleur">
                         <speaker>2ème VOLEUR.</speaker>
                         <l n="325">Son habit promet moins de profit que de peine :</l>
                         <l n="326">Le bien n'arrête point dans les mains de ces gens </l>
                         <l n="327">Affamés, et toujours à leur ventre indulgent.</l>
                     </sp>
-<sp who="#premier_voleur">
+<sp who="#premier-voleur">
                         <speaker>1er VOLEUR.</speaker>
                         <l n="328" part="I">Voyons-le toutefois.</l>
                     </sp>
@@ -738,7 +735,7 @@
                         <l n="332">Mais je fuirais en vain si faible et si lassée,</l>
                         <l n="333">Qu'avant qu'être en ce bois ils m'auraient devancée.</l>
                     </sp>
-<sp who="#premier_voleur">
+<sp who="#premier-voleur">
                         <speaker>1er VOLEUR.</speaker>
                         <l n="334" part="I">La bourse Camarade.</l>
                     </sp>
@@ -751,7 +748,7 @@
                         <l n="338">Ce vieil habillement, ce reste de mon bien,</l>
                         <l n="339">Et croyez que l'ayant vous ne me laissez rien.</l>
                     </sp>
-<sp who="#deuxieme_voleur">
+<sp who="#deuxieme-voleur">
                         <speaker>2ème VOLEUR.</speaker>
                         <l n="340">C'est trop, et ton trépas </l>
                         <note type="C">Il semble manquer une partie au vers 340.</note>
@@ -763,7 +760,7 @@
                         <l n="343">Appelant du secours, je hasarde ma vie,</l>
                         <l n="344" part="I">Il leur faut obéir.</l>
                     </sp>
-<sp who="#deuxieme_voleur">
+<sp who="#deuxieme-voleur">
                         <speaker>2ème VOLEUR.</speaker>
                         <l n="344" part="F">Si tu réponds un mot :</l>
                         <l n="345" part="I">Tu consultes pendard.</l>
@@ -772,7 +769,7 @@
                         <speaker>DORISTÉE.</speaker>
                         <l n="345" part="M">Je vous suis.</l>
                     </sp>
-<sp who="#deuxieme_voleur">
+<sp who="#deuxieme-voleur">
                         <speaker>2ème VOLEUR.</speaker>
                         <l n="345" part="F">Marche tôt.</l>
                     </sp>
@@ -794,7 +791,7 @@
 </div>
 <div type="scene" n="6">
                     <head>SCÈNE VI. Les Archers, Cléagénor.</head>
-<sp who="#premier_archer">
+<sp who="#premier-archer">
                         <speaker>1er ARCHER voyant le corps d'Ozanor.</speaker>
                         <l n="355" part="I">Arrête.</l>
                     </sp>
@@ -802,7 +799,7 @@
                         <speaker>CLÉAGÉNOR.</speaker>
                         <l n="355" part="M">Ô Dieux cruels !</l>
                     </sp>
-<sp who="#deuxieme_archer">
+<sp who="#deuxieme-archer">
                         <speaker>2ème ARCHER.</speaker>
                         <l n="355" part="F">Confesse l'homicide :</l>
                         <l n="356" part="I">Amis qu'on le saisisse.</l>
@@ -813,7 +810,7 @@
                         <l n="357">Il est vrai, cette mort est un coup de mes mains,</l>
                         <l n="358">Mais plus juste, cruels, que votre violence.</l>
                     </sp>
-<sp who="#premier_archer">
+<sp who="#premier-archer">
                         <speaker>1er ARCHER.</speaker>
                         <l n="359">On sait de tes pareils réprimer l'insolence :</l>
                         <l n="360" part="I">Donnons.</l>
@@ -840,7 +837,7 @@
                 <head>ACTE II</head>
 <div type="scene" n="1">
                     <head>SCÈNE I. Les deux Voleurs, Doristée, sous le nom de Philemond.</head>
-<sp who="#premier_voleur">
+<sp who="#premier-voleur">
                         <speaker>1er VOLEUR.</speaker>
                         <l n="366">Ami, puisque le sort t'appelle à l'exercice </l>
                         <l n="367">D'un si triste, si vil, mais profitable office :</l>
@@ -890,7 +887,7 @@
                         <l n="408">Et qu'on verra régner ma réputation </l>
                         <l n="409">Entre les plus hardis de la profession.</l>
                     </sp>
-<sp who="#deuxieme_voleur">
+<sp who="#deuxieme-voleur">
                         <speaker>2ème VOLEUR.</speaker>
                         <l n="410" part="I">Ton courage me plaît.</l>
                     </sp>
@@ -903,7 +900,7 @@
                         <l n="414">Ah ! Combien sentiront ma fureur inhumaine,</l>
                         <l n="415">Et de combien de sang va rougir cette plaine.</l>
                     </sp>
-<sp who="#premier_voleur">
+<sp who="#premier-voleur">
                         <speaker>1er VOLEUR.</speaker>
                         <l n="416" part="I">Fais plus et parle moins.</l>
                     </sp>
@@ -911,7 +908,7 @@
                         <speaker>PHILEMOND.</speaker>
                         <l n="416" part="F">Vous verrez au besoin.</l>
                     </sp>
-<sp who="#premier_voleur">
+<sp who="#premier-voleur">
                         <speaker>1er VOLEUR le posant en embuscade.</speaker>
                         <l n="417">De là, sans être vu, tu découvres de loin.</l>
                     </sp>
@@ -919,7 +916,7 @@
                         <speaker>PHILEMOND.</speaker>
                         <l n="418" part="I">Y serons-nous longtemps ?</l>
                     </sp>
-<sp who="#premier_voleur">
+<sp who="#premier-voleur">
                         <speaker>1er VOLEUR.</speaker>
                         <l n="418" part="F">Non. Et toi Camarade,</l>
                         <l n="419">Cet endroit te plaît-il, fais là ton embuscade ;</l>
@@ -948,7 +945,7 @@
                         <l n="439">Et je demeure en proie à leur main meurtrière :</l>
                         <l n="440">Je ne puis qu'au hasard d'un généreux trépas.</l>
                     </sp>
-<sp who="#deuxieme_voleur">
+<sp who="#deuxieme-voleur">
                         <speaker>2ème VOLEUR se penchant et découvrant des gens qui passent.</speaker>
                         <l n="441" part="I">St, st.</l>
                     </sp>
@@ -961,7 +958,7 @@
 </div>
 <div type="scene" n="2">
                     <head>SCÈNE II. Théandre, Philemond, Les Voleurs.</head>
-<sp who="#suite_de_theandre">
+<sp who="#suite-de-theandre">
                         <speaker>Suite de THEANDRE.</speaker>
                         <l n="444">Sus, le cerf reconnu, qu'un glorieux effort.</l>
                     </sp>
@@ -977,7 +974,7 @@
                         <speaker>THÉANDRE.</speaker>
                         <l n="450" part="I">Ciel, seconde mon bras.</l>
                     </sp>
-<sp who="#premier_voleur">
+<sp who="#premier-voleur">
                         <speaker>1er VOLEUR.</speaker>
                         <l n="450" part="F">Cédez à la prière.</l>
                     </sp>
@@ -989,7 +986,7 @@
                         <speaker>PHILEMOND se tournant de son côté.</speaker>
                         <l n="452" part="I">Donnons, Monsieur.</l>
                     </sp>
-<sp who="#deuxieme_voleur">
+<sp who="#deuxieme-voleur">
                         <speaker>2ème VOLEUR.</speaker>
                         <l n="452" part="M">Ha traître !</l>
                     </sp>
@@ -999,7 +996,7 @@
                         <l n="453">Je suis ce que m'enjoint le Ciel et la raison,</l>
                         <l n="454" part="I">Vous fuyez lâches coeurs.</l>
                     </sp>
-<sp who="#premier_voleur">
+<sp who="#premier-voleur">
                         <speaker>1er VOLEUR fuyant.</speaker>
                         <l n="454" part="F">Ô perfidie extrême.</l>
                     </sp>

--- a/tei/rousseau-devin-du-village.xml
+++ b/tei/rousseau-devin-du-village.xml
@@ -51,9 +51,6 @@
                     <person xml:id="colin" sex="MALE">
                         <persName>Colin</persName>
                     </person>
-                    <person xml:id="colin_colette" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Colin_colette</persName>
-                    </person>
                     <person xml:id="choeur" sex="UNKNOWN">
                         <persName>Troupe de Jeunes Gens du Village</persName>
                     </person>
@@ -576,7 +573,7 @@
                         <speaker>COLETTE.</speaker>
                         <l n="162">Je crains un amant volage.</l>
                     </sp>
-<sp who="#colin_colette">
+<sp who="#colin #colette">
                         <speaker>ENSEMBLE</speaker>
                         <l n="163">Je me dégage à mon tour.</l>
                         <l n="164">Mon coeur, devenu paisible,</l>
@@ -614,7 +611,7 @@
                         <l n="176">Faut-il t'aimer malgré moi !</l>
                         <stage type="kneel/throw/desdain/give/happy">Colin se jette aux pieds de Colette ; elle lui fait remarquer à son chapeau un ruban fort riche qu'il a reçu de la dame. Colin le jette avec dédain. Colette lui en donne un plus simple, dont elle était parée et qu'il reçoit avec transport.</stage>
                     </sp>
-<sp who="#colin_colette">
+<sp who="#colin #colette">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="177" part="I">À jamais Colin</l>
                     </sp>
@@ -634,7 +631,7 @@
                         <speaker>COLETTE</speaker>
                         <l n="178" part="F">Son coeur et sa foi.</l>
                     </sp>
-<sp who="#colin_colette">
+<sp who="#colin #colette">
                         <speaker>ENSEMBLE</speaker>
                         <l n="179">Qu'un doux mariage</l>
                         <l n="180">M'unisse à toi.</l>

--- a/tei/rousseau-muses-galantes.xml
+++ b/tei/rousseau-muses-galantes.xml
@@ -83,9 +83,6 @@
                     <person xml:id="chef-des-sarmates" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Chef des Sarmates</persName>
                     </person>
-                    <person xml:id="ovide_erithie" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Ovide_erithie</persName>
-                    </person>
                     <person xml:id="anacreon" sex="MALE">
                         <persName>Anacréon</persName>
                     </person>
@@ -97,9 +94,6 @@
                     </person>
                     <person xml:id="themire" sex="FEMALE">
                         <persName>Thémire</persName>
-                    </person>
-                    <person xml:id="themire_anacreon" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Themire_anacreon</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -825,7 +819,7 @@
                         <l n="347">Qui pourrait être assez profane</l>
                         <l n="348">Pour priver les Dieux de leurs droits ?</l>
                     </sp>
-<sp who="#ovide_erithie">
+<sp who="#ovide #erithie">
                         <speaker>OVIDE et ÉRITHIE.</speaker>
                         <l n="349">De plus puissant des Dieux nos cours sont le partage,</l>
                         <l n="350">Notre amour est son ouvrage :</l>
@@ -1164,7 +1158,7 @@
                         <l n="524">Vous attendrez mon inconstance,</l>
                         <l n="525">Et ne l'éprouverez jamais.</l>
                     </sp>
-<sp who="#themire_anacreon">
+<sp who="#themire #anacreon">
                         <speaker>ENSEMBLE.</speaker>
                         <l n="526">Unis par les mêmes désirs,</l>
                         <l n="527">Unissons mon sort et le vôtre ;</l>
@@ -1201,7 +1195,7 @@
                         <l n="545">Allez, soyez unis ; je puis être sensible ;</l>
                         <l n="546">Mais je n'oublierai point ma gloire et mon serment.</l>
                     </sp>
-<sp who="#themire_anacreon">
+<sp who="#themire #anacreon">
                         <speaker>THEMIRE et ANACRÉON.</speaker>
                         <l n="547">Digne exemple des rois, dont le coeur équitable</l>
                         <l n="548">Triomphe de soi-même en couronnant nos feux,</l>

--- a/tei/rousseaujb-ceinture-magique.xml
+++ b/tei/rousseaujb-ceinture-magique.xml
@@ -66,9 +66,6 @@
                     <person xml:id="francisque" sex="MALE">
                         <persName>Francisque</persName>
                     </person>
-                    <person xml:id="lucette_baliverne" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Lucette_baliverne</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -1481,7 +1478,7 @@ est attaché sur le manteau de l'autre, se met entre eux, et leur passe à chacu
 	<s n="1">Prenez ma houppelande, et gardez-vous bien de la gâter.</s>
 </p>
                     </sp>
-<sp who="#lucette_baliverne">
+<sp who="#lucette #baliverne">
                         <speaker>LUCETTE et BALIVERNE, apercevant les deux lettres.</speaker>
                         <p n="7">
 	<s n="1">Ah, ah, ah, ah, ah, ah !</s>

--- a/tei/rousseaujb-jason.xml
+++ b/tei/rousseaujb-jason.xml
@@ -51,9 +51,6 @@
                     <person xml:id="la-paix" sex="FEMALE">
                         <persName>La Paix</persName>
                     </person>
-                    <person xml:id="pan_paix" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Pan_paix</persName>
-                    </person>
                     <person xml:id="premier-berger" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Premier Berger</persName>
                     </person>
@@ -89,9 +86,6 @@
                     </person>
                     <person xml:id="une-nereide" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Une Nereide</persName>
-                    </person>
-                    <person xml:id="jason_hypsipile_orphee" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Jason_hypsipile_orphee</persName>
                     </person>
                     <person xml:id="l-amour" sex="MALE">
                         <persName>L'Amour</persName>
@@ -286,7 +280,7 @@
                         <l n="49">Laissons-les s'égarer dans leurs vagues projets,</l>
                         <l n="50">Et goûtons les douceurs d'un repos plein d'attraits.</l>
                     </sp>
-<sp who="#pan_paix">
+<sp who="#pan #la-paix">
                         <speaker>TOUS DEUX ENSEMBLE.</speaker>
                         <l n="51">Préparons des fêtes nouvelles:</l>
                         <l n="52">Rappelons en ces lieux l'amour et les plaisirs;</l>
@@ -1117,7 +1111,7 @@
                         <l n="544">Heureuse d'avoir pu juger par mes tourments</l>
                         <l n="545">De mon amour et de votre constance.</l>
                     </sp>
-<sp who="#jason_hypsipile_orphee">
+<sp who="#jason #hypsipile #orphee">
                         <speaker>JASON, HYPSIPILE, ORPHÉE.</speaker>
                         <l n="546">Ne nous plaignons point des rigueurs</l>
                         <l n="547">Où le tendre amour nous expose,</l>

--- a/tei/roy-compliment-14-mars-1750.xml
+++ b/tei/roy-compliment-14-mars-1750.xml
@@ -49,11 +49,11 @@
                     <person xml:id="mademoiselle-astraudy" sex="FEMALE">
                         <persName>Mademoiselle Astraudy</persName>
                     </person>
-                    <person xml:id="mademoisellle-astraudy" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Mademoisellle Astraudy</persName>
-                    </person>
                     <person xml:id="arlequin" sex="MALE">
                         <persName>Arlequin</persName>
+                    </person>
+                    <person xml:id="mademoisellle-astraudy" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Mademoisellle Astraudy</persName>
                     </person>
                 </listPerson>
             </particDesc>

--- a/tei/roy-compliment-7-avril-1750.xml
+++ b/tei/roy-compliment-7-avril-1750.xml
@@ -189,7 +189,7 @@
                         <l n="42">C'est Castor et Pollux, ces jumeaux si fameux</l>
                         <l n="43" part="I">Immortels l'un par l'autre.</l>
                     </sp>
-<sp who="#m-amiracle">
+<sp who="#monsieur-miracle">
                         <speaker>M. AMiracle.</speaker>
                         <l n="43" part="F">Ah ! Quel blasphème affreux !</l>
                     </sp>

--- a/tei/saint-aignan-martyre-marie-antoinette.xml
+++ b/tei/saint-aignan-martyre-marie-antoinette.xml
@@ -140,7 +140,7 @@
                     <person xml:id="tronson" sex="MALE">
                         <persName>Tronson</persName>
                     </person>
-                    <person xml:id="second-membre-du-comite-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                    <person xml:id="second-membre-du-comite" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Second Membre du Comite</persName>
                     </person>
                     <person xml:id="l-autre-membre" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->

--- a/tei/saint-foix-ile-sauvage.xml
+++ b/tei/saint-foix-ile-sauvage.xml
@@ -62,9 +62,6 @@
                     <person xml:id="beatrix" sex="FEMALE">
                         <persName>Béatrix</persName>
                     </person>
-                    <person xml:id="leonor-et-rosette" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Leonor et Rosette</persName>
-                    </person>
                     <person xml:id="don-gusman" sex="MALE">
                         <persName>Don Gusman</persName>
                     </person>
@@ -538,7 +535,7 @@
 </div>
 <div type="scene" n="4">
                     <head>SCÈNE IV. Béatrix, Léonor, Rosette, Félix.</head>
-<sp who="#leonor-et-rosette">
+<sp who="#leonor #rosette">
                         <speaker>LÉONOR et ROSETTE, accourant.</speaker>
                         <p n="1">
 	<s n="1">Ma mère ?</s>

--- a/tei/saint-foix-oracle.xml
+++ b/tei/saint-foix-oracle.xml
@@ -556,7 +556,7 @@
 	<s n="6">Oui...</s>
 </p>
                     </sp>
-<sp who="#la-fee,-la-contrefaisant">
+<sp who="#la-fee">
                         <speaker>LA FÉE, la contrefaisant.</speaker>
                         <p n="7">
 	<s n="">Ah !... </s>

--- a/tei/scribe-les-dervis.xml
+++ b/tei/scribe-les-dervis.xml
@@ -75,9 +75,6 @@
                     <person xml:id="isabelle" sex="FEMALE">
                         <persName>Isabelle</persName>
                     </person>
-                    <person xml:id="arlequin-et-taher" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Arlequin et Taher</persName>
-                    </person>
                     <person xml:id="les-esclaves" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Esclaves</persName>
                     </person>
@@ -1512,7 +1509,7 @@
                         <speaker>ISABELLE.</speaker>
                         <l n="199">Ah ! Que mon coeur est agité !</l>
                     </sp>
-<sp who="#lelio #arlequin-et-taher">
+<sp who="#lelio #arlequin #taher">
                         <speaker>LÉLIO, ARLEQUIN et TAHER.</speaker>
                         <l n="200">On respecte ici la beauté,</l>
                         <l n="201">Entrez dans cette enceinte !</l>

--- a/tei/scudery-vassal-genereux.xml
+++ b/tei/scudery-vassal-genereux.xml
@@ -197,7 +197,7 @@
 			<castItem>
                     <role corresp="#choeur-de-gaulois">CHOEUR DES PEUPLES GAULOIS</role>.</castItem>
 			<castItem>
-                    <role corresp="#choeur_trompettes">CHOEUR DE TROMPETTES</role>.</castItem>
+                    <role corresp="#choeur-trompettes">CHOEUR DE TROMPETTES</role>.</castItem>
 		</castList>
 	<!--TODO: usage of set in correct place but with unknown attributes <set location="France" country="France" periode="(inconnue)" gps="(N/A)"/>-->
 	</front>

--- a/tei/sedaine-manteau-ecarlate.xml
+++ b/tei/sedaine-manteau-ecarlate.xml
@@ -62,9 +62,6 @@
                     <person xml:id="blaise" sex="MALE">
                         <persName>Blaise</persName>
                     </person>
-                    <person xml:id="blaise_gerault" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Blaise_gerault</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -1759,7 +1756,7 @@
 	<s n="1">Blaise et Gérault, sortez.</s>
 </p>
                     </sp>
-<sp who="#blaise_gerault">
+<sp who="#blaise #gerault">
                         <speaker>BLAISE et GÉRAULT.</speaker>
                         <p n="40">
 	<s n="1">Au moins, Monsieur, soyez bien persuadé.....</s>

--- a/tei/sedaine-richard.xml
+++ b/tei/sedaine-richard.xml
@@ -97,14 +97,11 @@
                     <person xml:id="richard" sex="MALE">
                         <persName>Richard</persName>
                     </person>
-                    <person xml:id="blondel-et-richard" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Blondel et Richard</persName>
-                    </person>
                     <person xml:id="les-soldats" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Soldats</persName>
                     </person>
-                    <person xml:id="les-officiers-et-les-soldats" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Les Officiers et les Soldats</persName>
+                    <person xml:id="les-officiers" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Officiers</persName>
                     </person>
                     <person xml:id="un-soldat" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Soldat</persName>
@@ -120,9 +117,6 @@
                     </person>
                     <person xml:id="les-chevaliers" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Chevaliers</persName>
-                    </person>
-                    <person xml:id="beatrix-et-la-comtesse" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Beatrix et la Comtesse</persName>
                     </person>
                     <person xml:id="un-paysan" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Un Paysan</persName>
@@ -1684,7 +1678,7 @@
                         <l n="188">Si Marguerite était ici,</l>
                         <l n="189">Je m'écrierais plus de souci.</l>
                     </sp>
-<sp who="#blondel-et-richard">
+<sp who="#blondel #richard">
                         <speaker>BLONDEL et RICHARD, ensemble.</speaker>
                         <l n="190" part="I">Un regard de ma belle</l>
                         <l n="190" part="F">Un regard de sa belle</l>
@@ -1753,7 +1747,7 @@
                         <l n="220">Pour un avis important</l>
                         <l n="221">Qu'il doit savoir à l'instant.</l>
                     </sp>
-<sp who="#les-officiers-et-les-soldats">
+<sp who="#les-officiers #les-soldats">
                         <speaker>LES OFFICIERS ET LES SOLDATS.</speaker>
                         <l n="222">Tu vas parler à monseigneur,</l>
                         <l n="223">À Monseigneur le gouverneur.</l>
@@ -2313,7 +2307,7 @@
                         <l n="318">Ah, grands dieux... ! Ah ! Mon coeur se serre</l>
                         <l n="319">De joie et de saisissement.</l>
                     </sp>
-<sp who="#les-chevaliers #williams #beatrix-et-la-comtesse">
+<sp who="#les-chevaliers #williams #beatrix #la-comtesse">
                         <speaker>LES CHEVALIERS, WILLIAMS, BÉATRIX ET LA COMTESSE.</speaker>
                         <l n="320">Ah, grands dieux ! quel étonnement !</l>
                         <l n="321">Quel bonheur ! quel événement !</l>

--- a/tei/sewrin-la-sorciere.xml
+++ b/tei/sewrin-la-sorciere.xml
@@ -73,7 +73,7 @@
                     <person xml:id="les-choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Choeurs</persName>
                     </person>
-                    <person xml:id="alix" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                    <person xml:id="alix" sex="MALE">
                         <persName>Alix</persName>
                     </person>
                     <person xml:id="enfants-de-choeur" sex="MALE">
@@ -132,7 +132,7 @@
 			<castItem>
                     <role corresp="#bebee">BEBÉE</role>, première femme de Fiston. Mlle. JULIE.</castItem>
 			<castItem>
-                    <role corresp="#empty-string">ALIX</role>, servante de Bebée. M. BRUNET.</castItem>
+                    <role corresp="#alix">ALIX</role>, servante de Bebée. M. BRUNET.</castItem>
 			<castItem>
                     <role corresp="#deux-enfants">DEUX ENFANTS</role>.</castItem>
 			<castItem>

--- a/tei/vade-veuve-indecise.xml
+++ b/tei/vade-veuve-indecise.xml
@@ -56,9 +56,6 @@
                     <person xml:id="suson" sex="FEMALE">
                         <persName>Suson</persName>
                     </person>
-                    <person xml:id="mathurin-et-colin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Mathurin et Colin</persName>
-                    </person>
                     <person xml:id="ensemble" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Ensemble</persName>
                     </person>
@@ -374,7 +371,7 @@
                         <speaker>SUSON.</speaker>
                         <l n="54">Lequel des deux....</l>
                     </sp>
-<sp who="#mathurin-et-colin">
+<sp who="#mathurin #colin">
                         <speaker>MATHURIN et COLIN.</speaker>
                         <l n="55">Aimes tu mieux ? </l>
                     </sp>
@@ -438,7 +435,7 @@
                         <l n="73">Oh ! Je le crois,</l>
                         <l n="74">Ce sera moi ?</l>
                     </sp>
-<sp who="#mathurin-et-colin">
+<sp who="#mathurin #colin">
                         <speaker>MATHURIN et COLIN.</speaker>
                         <l n="75">Décide-toi.</l>
                     </sp>

--- a/tei/vander-burch-proces-racine-conciliateur.xml
+++ b/tei/vander-burch-proces-racine-conciliateur.xml
@@ -51,14 +51,11 @@
                     <person xml:id="patafflard" sex="MALE">
                         <persName>Patafflard</persName>
                     </person>
-                    <person xml:id="thomas-et-mathurin" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Thomas et Mathurin</persName>
+                    <person xml:id="thomas" sex="MALE">
+                        <persName>Thomas</persName>
                     </person>
                     <person xml:id="mathurin" sex="MALE">
                         <persName>Mathurin</persName>
-                    </person>
-                    <person xml:id="thomas" sex="MALE">
-                        <persName>Thomas</persName>
                     </person>
                     <person xml:id="racine" sex="MALE">
                         <persName>Racine</persName>
@@ -267,7 +264,7 @@ quand je serai plus grand, vous me l'apprendrez ; je veux devenir savant comme v
 calamo, nous commencerons musa la musique. </s>
 </p>
                     </sp>
-<sp who="#thomas-et-mathurin">
+<sp who="#thomas #mathurin">
                         <speaker>THOMAS ET MATHURIN, appelant chacun d'un côté.</speaker>
                         <p n="18">
 	<s n="1">Nicolas !... </s>

--- a/tei/voisenon-hilas-et-zelis.xml
+++ b/tei/voisenon-hilas-et-zelis.xml
@@ -68,8 +68,8 @@
                     <person xml:id="le-grand-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Le Grand Choeur</persName>
                     </person>
-                    <person xml:id="zelis-et-les-choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Zelis et les Choeurs</persName>
+                    <person xml:id="les-choeurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Les Choeurs</persName>
                     </person>
                 </listPerson>
             </particDesc>
@@ -462,7 +462,7 @@ Les Sieurs Hyacinte, Dubois, Grosset, Dauberval.</p>
                         <l n="142">Fais de ces beaux lieux</l>
                         <l n="143">Le séjour des ris et des jeux.</l>
                     </sp>
-<sp who="#zelis-et-les-choeurs">
+<sp who="#zelis #les-choeurs">
                         <speaker>ZÉLIS et les CHOEURS.</speaker>
                         <l n="144">Par tes bienfaits,</l>
                         <l n="145">Règne à jamais.</l>

--- a/tei/voltaire-depositaire.xml
+++ b/tei/voltaire-depositaire.xml
@@ -84,9 +84,6 @@
                     <person xml:id="monsieur-armand" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Monsieur Armand</persName>
                     </person>
-                    <person xml:id="monsieur-armand-" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Monsieur Armand</persName>
-                    </person>
                     <person xml:id="monsieur-garand" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Monsieur Garand</persName>
                     </person>

--- a/tei/voltaire-deux-tonneaux.xml
+++ b/tei/voltaire-deux-tonneaux.xml
@@ -53,9 +53,6 @@
                     <person xml:id="prestine" sex="FEMALE">
                         <persName>Prestine</persName>
                     </person>
-                    <person xml:id="gregoire-et-prestine" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Gregoire et Prestine</persName>
-                    </person>
                     <person xml:id="glycere" sex="MALE">
                         <persName>Glycère</persName>
                     </person>
@@ -396,7 +393,7 @@
                         <speaker>PRESTINE.</speaker>
                         <l n="126" part="F">Hélas ! très volontiers.</l>
                     </sp>
-<sp who="#gregoire-et-prestine">
+<sp who="#gregoire #prestine">
                         <speaker>GRÉGOIRE ET PRESTINE.</speaker>
                         <stage type="title">DUO.</stage>
                         <ab type="chanson"><!--<poem>-->

--- a/tei/voltaire-envieux.xml
+++ b/tei/voltaire-envieux.xml
@@ -146,7 +146,7 @@
 	<castItem>
                     <role corresp="#gardes">GARDES</role>.</castItem>
 	<castItem>
-                    <role corresp="#plusieurs_valets">PLUSIEURS VALETS</role> de la suite de Cléon.</castItem>
+                    <role corresp="#plusieurs-valets">PLUSIEURS VALETS</role> de la suite de Cléon.</castItem>
 </castList>
 <!--TODO: usage of set in correct place but with unknown attributes <set location="(non indiqué)" country="France" periode="XVIIIème" gps="(N/A)">La scène est dans le château de Cléon.</set>-->
 <note>Selon Henri Lagrave, dans l'article "L'Envieux" de l'Inventaire Voltaire (Paris, Gallimard, 1995, p. 481-482), il s'agit d'une pièce "en trois actes en vers (1738)". C'est aussi une pièce à clefs dont voici les principaux personnages : Ariston est Voltaire, Cléon est M. Du Châtelet, Hortense est Mme Du Châtelet, Zoïlin est abbé Desfontaines. "Prête dès le mois de juillet, la pièce devait être jouée à la Comédie-Française, sous le nom d'emprunt de Lamarre. Elle eût servi de réponse à la terrible Voltairomanie de l'abbé, si Emilie, d'accord avec d'Argental, n'avait tout fait pour en empêcher la représentation avec succès. L'Envieux ne fut imprimé qu'en 1833." [information isuue du site ceasar.org.uk]</note>

--- a/tei/voltaire-femme-qui-a-raison.xml
+++ b/tei/voltaire-femme-qui-a-raison.xml
@@ -65,9 +65,6 @@
                     <person xml:id="monsieur-duru" sex="MALE">
                         <persName>Monsieur Duru</persName>
                     </person>
-                    <person xml:id="damis_erise_le-marquis" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Damis_erise_le Marquis</persName>
-                    </person>
                 </listPerson>
             </particDesc>
             <textClass>
@@ -2308,7 +2305,7 @@
                         <speaker>MADAME DURU.</speaker>
                         <l n="757" part="I">Quoi ! C'est vous, mon mari, mon cher époux ?...</l>
                     </sp>
-<sp who="#damis_erise_le-marquis">
+<sp who="#damis #erise #le-marquis">
                         <speaker>DAMIS, ÉRISE, LE MARQUIS, ensemble.</speaker>
                         <l n="757" part="F">Mon père !</l>
                     </sp>

--- a/tei/voltaire-pandore.xml
+++ b/tei/voltaire-pandore.xml
@@ -57,8 +57,8 @@
                     <person xml:id="encelade" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Encelade</persName>
                     </person>
-                    <person xml:id="promethee_deux-titans" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Promethee_deux Titans</persName>
+                    <person xml:id="deux-titans" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Deux Titans</persName>
                     </person>
                     <person xml:id="choeur-des-dieux-infernaux" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur des Dieux Infernaux</persName>
@@ -92,9 +92,6 @@
                     </person>
                     <person xml:id="mercure" sex="MALE">
                         <persName>Mercure</persName>
-                    </person>
-                    <person xml:id="pandore_promethee" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Pandore_promethee</persName>
                     </person>
                     <person xml:id="jupiter" sex="MALE">
                         <persName>Jupiter</persName>
@@ -273,7 +270,7 @@
                         <l n="33">Que Jupiter en frémisse d'envie, </l>
                         <l n="34">Et qu'il soit vainement jaloux. </l>
                     </sp>
-<sp who="#promethee_deux-titans">
+<sp who="#promethee #deux-titans">
                         <speaker>PROMÉTHÉE et les DEUX TITANS.</speaker>
                         <l n="35">Écoutez-nous, dieux de la nuit profonde : </l>
                         <l n="36">De nos astres nouveaux contemplez la clarté : </l>
@@ -562,7 +559,7 @@
                         <speaker>PROMÉTHÉE.</speaker>
                         <l n="205">Cruels ! ayez pitié de ma douleur extrême. </l>
                     </sp>
-<sp who="#pandore_promethee">
+<sp who="#pandore #promethee">
                         <speaker>PANDORE et PROMÉTHÉE.</speaker>
                         <l n="206">Barbares, arrêtez. </l>
                     </sp>

--- a/tei/voltaire-rome-sauvee.xml
+++ b/tei/voltaire-rome-sauvee.xml
@@ -83,8 +83,11 @@
                     <person xml:id="clodius" sex="MALE">
                         <persName>Clodius</persName>
                     </person>
-                    <person xml:id="chef_licteurs" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Chef_licteurs</persName>
+                    <person xml:id="chef" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
+                        <persName>Chef</persName>
+                    </person>
+                    <person xml:id="licteurs" sex="MALE">
+                        <persName>Licteurs</persName>
                     </person>
                     <person xml:id="crassus" sex="MALE">
                         <persName>Crassus</persName>
@@ -2167,7 +2170,7 @@ Ce que peu de personnes savent, c'est que Cicéron était encore un des premiers
 </div>
 <div type="scene" n="6">
                     <head>SCÈNE VI. Le Sénat, Aurélie, le chef des licteurs.</head>	
-<sp who="#chef_licteurs">
+<sp who="#chef #licteurs">
                         <speaker>LE CHEF DES LICTEURS.</speaker>
                         <l n="1193">Seigneur, on a saisi ce dépôt formidable.</l>
                     </sp>
@@ -2175,7 +2178,7 @@ Ce que peu de personnes savent, c'est que Cicéron était encore un des premiers
                         <speaker>CICÉRON.</speaker>
                         <l n="1194" part="I">Chez Nonnius ?</l>
                     </sp>
-<sp who="#chef_licteurs">
+<sp who="#chef #licteurs">
                         <speaker>LE CHEF DES LICTEURS.</speaker>
                         <l n="1194" part="F">Chez lui. Ceux qui sont arrêtés</l>
                         <l n="1195">N'accusent que lui seul de tant d'iniquités.</l>
@@ -2318,7 +2321,7 @@ Ce que peu de personnes savent, c'est que Cicéron était encore un des premiers
 </div>
 <div type="scene" n="7">
                     <head>SCÈNE VII. Le sénat, le chef des licteurs.</head>
-<sp who="#chef_licteurs">
+<sp who="#chef #licteurs">
                         <speaker>LE CHEF DES LICTEURS.</speaker>
                         <l n="1268">Seigneur, en secourant la mourante Aurélie,</l>
                         <l n="1269">Que nos soins vainement rappelaient à la vie,</l>

--- a/tei/voltaire-samson.xml
+++ b/tei/voltaire-samson.xml
@@ -119,9 +119,6 @@
                     <person xml:id="deux-hebreux" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Deux Hebreux</persName>
                     </person>
-                    <person xml:id="samson_dalila" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Samson_dalila</persName>
-                    </person>
                     <person xml:id="guerriers" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Guerriers</persName>
                     </person>
@@ -133,9 +130,6 @@
                     </person>
                     <person xml:id="les-philistins" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Les Philistins</persName>
-                    </person>
-                    <person xml:id="samson_deux-coryphees" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Samson_deux Coryphees</persName>
                     </person>
                     <person xml:id="choeur-d-israelites" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Choeur D Israelites</persName>
@@ -1124,7 +1118,7 @@
                         <l n="520">Mais de tous les sujets que vous venez de faire,</l>
                         <l n="521">Mon cour vous est le plus soumis.</l>
                     </sp>
-<sp who="#samson_dalila">
+<sp who="#samson #dalila">
                         <speaker>SAMSON ET DALILA, ensemble.</speaker>
                         <l n="522">N'écoutons plus le bruit des armes ;</l>
                         <l n="523">Myrtes amoureux, croissez près des lauriers ;</l>
@@ -1308,7 +1302,7 @@
                         <l n="612">Ma raison revient ; je frissonne</l>
                         <l n="613">De l'abîme où j'entraîne avec moi les Hébreux.</l>
                     </sp>
-<sp who="#samson_dalila">
+<sp who="#samson #dalila">
                         <speaker>TOUS DEUX ensemble.</speaker>
                         <l n="614">La terre mugit, le ciel tonne,</l>
                         <l n="615">Le temple disparaît, l'astre du jour s'enfuit,</l>
@@ -1466,7 +1460,7 @@
                         <l n="690">Frappez, tonnerre,</l>
                         <l n="691">Écrasez-moi !</l>
                     </sp>
-<sp who="#samson_deux-coryphees">
+<sp who="#samson #deux-coryphees">
                         <speaker>SAMSON ET DEUX CORYPHEES.</speaker>
                         <stage type="title">TRIO.</stage>
                         <l n="692">Amour, tyran que je déteste,</l>

--- a/tei/voltaire-tanis-zelide.xml
+++ b/tei/voltaire-tanis-zelide.xml
@@ -81,17 +81,14 @@
                     <person xml:id="cleofis" sex="MALE">
                         <persName>Cléofis</persName>
                     </person>
-                    <person xml:id="isis_osiris" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Isis_osiris</persName>
+                    <person xml:id="isis" sex="FEMALE">
+                        <persName>Isis</persName>
                     </person>
-                    <person xml:id="tanis_zelide" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Tanis_zelide</persName>
+                    <person xml:id="osiris" sex="MALE">
+                        <persName>Osiris</persName>
                     </person>
                     <person xml:id="grand-choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Grand Choeur</persName>
-                    </person>
-                    <person xml:id="tanis_choeur" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
-                        <persName>Tanis_choeur</persName>
                     </person>
                     <person xml:id="oroes" sex="UNKNOWN"><!--WARNING: no castItem found for reference in @who-->
                         <persName>Oroes</persName>
@@ -614,7 +611,7 @@
 </div>
 <div type="scene" n="3">
                     <head>SCÈNE III. Isis et Osiris, dans le nuage ; Tanois, Cléofis.</head>
-<sp who="#isis_osiris">
+<sp who="#isis #osiris">
                         <speaker>ISIS ET OSIRIS.</speaker>
                         <l n="223">L'Amour te conduira dans la cité barbare </l>
                         <l n="224">Où les mages donnent la loi ; </l>
@@ -707,7 +704,7 @@
                         <l n="272">Tanis me tiendra lieu de la nature entière : </l>
                         <l n="273">Je n'y vois plus rien que nous deux. </l>
                     </sp>
-<sp who="#tanis_zelide">
+<sp who="#tanis #zelide">
                         <speaker>TANIS et ZÉLIDE.</speaker>
                         <l n="274">Osiris que l'amour engage, </l>
                         <l n="275">Toujours aimé d'Isis, et toujours amoureux. </l>
@@ -913,7 +910,7 @@
                         <speaker>CLÉOFIS.</speaker>
                         <l n="382">Ô perfidie ! Ô crime ! Ô douleur éternelle ! </l>
                     </sp>
-<sp who="#tanis_choeur">
+<sp who="#tanis #choeur">
                         <speaker>TANIS et le CHOEUR.</speaker>
                         <l n="383">Ciel ! Quels maux nous annoncez-vous ? </l>
                     </sp>
@@ -1269,7 +1266,7 @@
                         <l n="555">Ils font éclater leur puissance ; </l>
                         <l n="556">Ils étendent leur bras vengeur. </l>
                     </sp>
-<sp who="#tanis_zelide">
+<sp who="#tanis #zelide">
                         <speaker>ZÉLIDE et TANIS.</speaker>
                         <l n="557">Dieux bienfaisants, achevez votre ouvrage ; </l>
                         <l n="558">Délivrez l'innocent qui n'espère qu'en vous ; </l>


### PR DESCRIPTION
This PR is aims to make the transformation of `who` attributes and `castList` elements in the theatre-classique sources into  FreDraCor `particDesc` elements more robust. Instead of trying to fix the mistakes and oddities in the sources programmatically it attempts to implement the rules inherent in them. From now on, in the sources, we expect the following:

- `who` attributes to be correctly spelled
- speakers can be identified by words or phrases. These can include spaces, dashes, numbers, accented characters which will all be normalised when transformed into XML IDs
- multiple speakers in the same `who` attribute are separated by either comma, underscore or forward slash (an " et " will not be considered a separator)
- the same speaker must be identified by the same word or phrase

Deviations from these rules need to be corrected on the `dracor` branch of the [theatre-classique](https://github.com/dracor-org/theatre-classique) repo. In fact, most of the TEI changes in this PR have already been originated by changes in the `dracor` branch. See https://github.com/dracor-org/theatre-classique/compare/dracor for details.

resolve #15 
resolve #20 